### PR TITLE
MAGETWO-49985: product custom options export in reverse order fixed

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Export/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Export/Product.php
@@ -1315,8 +1315,7 @@ class Product extends \Magento\ImportExport\Model\Export\Entity\AbstractEntity
             }
             $options = $this->_optionColFactory->create();
             /* @var \Magento\Catalog\Model\ResourceModel\Product\Option\Collection $options*/
-            $options->addOrder('sort_order');
-            $options->reset()->addOrder('sort_order')->addTitleToResult(
+            $options->reset()->addOrder('sort_order', 'ASC')->addTitleToResult(
                 $storeId
             )->addPriceToResult(
                 $storeId

--- a/app/code/Magento/CatalogImportExport/Model/Export/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Export/Product.php
@@ -1315,15 +1315,12 @@ class Product extends \Magento\ImportExport\Model\Export\Entity\AbstractEntity
             }
             $options = $this->_optionColFactory->create();
             /* @var \Magento\Catalog\Model\ResourceModel\Product\Option\Collection $options*/
-            $options->reset()->addOrder('sort_order', 'ASC')->addTitleToResult(
-                $storeId
-            )->addPriceToResult(
-                $storeId
-            )->addProductToFilter(
-                $productIds
-            )->addValuesToResult(
-                $storeId
-            );
+            $options->reset();
+            $options->addOrder('sort_order', 'ASC');
+            $options->addTitleToResult($storeId);
+            $options->addPriceToResult($storeId);
+            $options->addProductToFilter($productIds);
+            $options->addValuesToResult($storeId);
 
             foreach ($options as $option) {
                 $row = [];


### PR DESCRIPTION
### Description
Changed the sort order from descending to ascending while getting custom options for a product, currently default sort order (descending) was used while generating rows for custom options for a product, so now after importing custom options will be displayed in the same order as in which these were exported.

### Manual testing scenarios
1. Create a simple product with two options, the 1st option is a dropdown and the 2nd option is a field, Save it.
2. System -> Export
3. System -> Import same file in same store or other
4. After import, in UI, product options will be in the same order as in it was exported.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)