### PR TITLE
Memory error on customer import

### DIFF
--- a/app/code/Magento/CustomerImportExport/Model/Import/CustomerComposite.php
+++ b/app/code/Magento/CustomerImportExport/Model/Import/CustomerComposite.php
@@ -308,14 +308,13 @@ class CustomerComposite extends \Magento\ImportExport\Model\Import\AbstractEntit
                 // Add new customer data into customer storage for address entity instance
                 $websiteId = $this->_customerEntity->getWebsiteId($this->_currentWebsiteCode);
                 if (!$this->_addressEntity->getCustomerStorage()->getCustomerId($this->_currentEmail, $websiteId)) {
-                    $customerData = new \Magento\Framework\DataObject(
+                    $this->_addressEntity->getCustomerStorage()->addCustomerByArray(
                         [
                             'id' => $this->_nextCustomerId,
                             'email' => $this->_currentEmail,
                             'website_id' => $websiteId,
                         ]
                     );
-                    $this->_addressEntity->getCustomerStorage()->addCustomer($customerData);
                     $this->_nextCustomerId++;
                 }
 

--- a/app/code/Magento/CustomerImportExport/Model/Import/CustomerComposite.php
+++ b/app/code/Magento/CustomerImportExport/Model/Import/CustomerComposite.php
@@ -310,7 +310,7 @@ class CustomerComposite extends \Magento\ImportExport\Model\Import\AbstractEntit
                 if (!$this->_addressEntity->getCustomerStorage()->getCustomerId($this->_currentEmail, $websiteId)) {
                     $this->_addressEntity->getCustomerStorage()->addCustomerByArray(
                         [
-                            'id' => $this->_nextCustomerId,
+                            'entity_id' => $this->_nextCustomerId,
                             'email' => $this->_currentEmail,
                             'website_id' => $websiteId,
                         ]

--- a/app/code/Magento/CustomerImportExport/Model/ResourceModel/Import/Customer/Storage.php
+++ b/app/code/Magento/CustomerImportExport/Model/ResourceModel/Import/Customer/Storage.php
@@ -81,11 +81,7 @@ class Storage
             $select->from($this->_customerCollection->getMainTable(), ['entity_id', 'website_id', 'email']);
             $results = $connection->fetchAll($select);
             foreach ($results as $customer) {
-                $email = strtolower(trim($customer['email']));
-                if (!isset($this->_customerIds[$email])) {
-                    $this->_customerIds[$email] = [];
-                }
-                $this->_customerIds[$email][$customer['website_id']] = $customer['entity_id'];
+                $this->addCustomerByArray($customer);
             }
 
             $this->_isCollectionLoaded = true;
@@ -93,18 +89,30 @@ class Storage
     }
 
     /**
+     * @param array $customer
+     * @return $this
+     */
+    public function addCustomerByArray(array $customer)
+    {
+        $email = strtolower(trim($customer['email']));
+        if (!isset($this->_customerIds[$email])) {
+            $this->_customerIds[$email] = [];
+        }
+        $this->_customerIds[$email][$customer['website_id']] = $customer['entity_id'];
+
+        return $this;
+    }
+
+    /**
      * Add customer to array
      *
+     * @deprecated @see addCustomerByArray
      * @param \Magento\Framework\DataObject|\Magento\Customer\Model\Customer $customer
      * @return $this
      */
     public function addCustomer(\Magento\Framework\DataObject $customer)
     {
-        $email = strtolower(trim($customer->getEmail()));
-        if (!isset($this->_customerIds[$email])) {
-            $this->_customerIds[$email] = [];
-        }
-        $this->_customerIds[$email][$customer->getWebsiteId()] = $customer->getId();
+        $this->addCustomerByArray($customer->toArray());
 
         return $this;
     }

--- a/app/code/Magento/CustomerImportExport/Model/ResourceModel/Import/Customer/Storage.php
+++ b/app/code/Magento/CustomerImportExport/Model/ResourceModel/Import/Customer/Storage.php
@@ -112,7 +112,11 @@ class Storage
      */
     public function addCustomer(\Magento\Framework\DataObject $customer)
     {
-        $this->addCustomerByArray($customer->toArray());
+        $customerData = $customer->toArray();
+        if (!isset($customerData['entity_id']) && isset($customer['id'])) {
+            $customerData['entity_id'] = $customerData['id'];
+        }
+        $this->addCustomerByArray($customerData);
 
         return $this;
     }

--- a/app/code/Magento/CustomerImportExport/Test/Unit/Model/Import/AddressTest.php
+++ b/app/code/Magento/CustomerImportExport/Test/Unit/Model/Import/AddressTest.php
@@ -8,6 +8,12 @@ namespace Magento\CustomerImportExport\Test\Unit\Model\Import;
 
 use Magento\CustomerImportExport\Model\Import\Address;
 use Magento\ImportExport\Model\Import\AbstractEntity;
+use Magento\Framework\DB\Select;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Customer\Model\ResourceModel\Customer\Collection;
+use Magento\Customer\Model\ResourceModel\Customer\CollectionFactory;
+use Magento\ImportExport\Model\ResourceModel\CollectionByPagesIteratorFactory;
+use Magento\CustomerImportExport\Model\ResourceModel\Import\Customer\Storage;
 
 /**
  * Class AddressTest
@@ -233,14 +239,14 @@ class AddressTest extends \PHPUnit\Framework\TestCase
      */
     protected function _createCustomerStorageMock()
     {
-        /** @var \Magento\Framework\DB\Select|\PHPUnit_Framework_MockObject_MockObject $selectMock */
-        $selectMock = $this->getMockBuilder(\Magento\Framework\DB\Select::class)
+        /** @var Select|\PHPUnit_Framework_MockObject_MockObject $selectMock */
+        $selectMock = $this->getMockBuilder(Select::class)
             ->disableOriginalConstructor()
             ->setMethods(['from'])
             ->getMock();
         $selectMock->expects($this->any())->method('from')->will($this->returnSelf());
 
-        /** @var $connectionMock \Magento\Framework\DB\Adapter\AdapterInterface|\PHPUnit_Framework_MockObject_MockObject */
+        /** @var $connectionMock AdapterInterface|\PHPUnit_Framework_MockObject_MockObject */
         $connectionMock = $this->getMockBuilder(\Magento\Framework\DB\Adapter\Pdo\Mysql::class)
             ->disableOriginalConstructor()
             ->setMethods(['select', 'fetchAll'])
@@ -249,8 +255,8 @@ class AddressTest extends \PHPUnit\Framework\TestCase
             ->method('select')
             ->will($this->returnValue($selectMock));
 
-        /** @var \Magento\Customer\Model\ResourceModel\Customer\Collection|\PHPUnit_Framework_MockObject_MockObject $customerCollection */
-        $customerCollection = $this->getMockBuilder(\Magento\Customer\Model\ResourceModel\Customer\Collection::class)
+        /** @var Collection|\PHPUnit_Framework_MockObject_MockObject $customerCollection */
+        $customerCollection = $this->getMockBuilder(Collection::class)
             ->disableOriginalConstructor()
             ->setMethods(['getConnection'])
             ->getMock();
@@ -258,8 +264,8 @@ class AddressTest extends \PHPUnit\Framework\TestCase
             ->method('getConnection')
             ->will($this->returnValue($connectionMock));
 
-        /** @var \Magento\Customer\Model\ResourceModel\Customer\CollectionFactory|\PHPUnit_Framework_MockObject_MockObject $collectionFactory */
-        $collectionFactory = $this->getMockBuilder(\Magento\Customer\Model\ResourceModel\Customer\CollectionFactory::class)
+        /** @var CollectionFactory|\PHPUnit_Framework_MockObject_MockObject $collectionFactory */
+        $collectionFactory = $this->getMockBuilder(CollectionFactory::class)
             ->disableOriginalConstructor()
             ->setMethods(['create'])
             ->getMock();
@@ -267,14 +273,14 @@ class AddressTest extends \PHPUnit\Framework\TestCase
             ->method('create')
             ->willReturn($customerCollection);
 
-        /** @var \Magento\ImportExport\Model\ResourceModel\CollectionByPagesIteratorFactory|\PHPUnit_Framework_MockObject_MockObject $byPagesIteratorFactory */
-        $byPagesIteratorFactory = $this->getMockBuilder(\Magento\ImportExport\Model\ResourceModel\CollectionByPagesIteratorFactory::class)
+        /** @var CollectionByPagesIteratorFactory|\PHPUnit_Framework_MockObject_MockObject $byPagesIteratorFactory */
+        $byPagesIteratorFactory = $this->getMockBuilder(CollectionByPagesIteratorFactory::class)
             ->disableOriginalConstructor()
             ->setMethods(['create'])
             ->getMock();
 
-        /** @var \Magento\CustomerImportExport\Model\ResourceModel\Import\Customer\Storage|\PHPUnit_Framework_MockObject_MockObject $customerStorage */
-        $customerStorage = $this->getMockBuilder(\Magento\CustomerImportExport\Model\ResourceModel\Import\Customer\Storage::class)
+        /** @var Storage|\PHPUnit_Framework_MockObject_MockObject $customerStorage */
+        $customerStorage = $this->getMockBuilder(Storage::class)
             ->setMethods(['load'])
             ->setConstructorArgs([$collectionFactory, $byPagesIteratorFactory])
             ->getMock();

--- a/app/code/Magento/CustomerImportExport/Test/Unit/Model/ResourceModel/Import/Customer/StorageTest.php
+++ b/app/code/Magento/CustomerImportExport/Test/Unit/Model/ResourceModel/Import/Customer/StorageTest.php
@@ -26,14 +26,56 @@ class StorageTest extends \PHPUnit\Framework\TestCase
 
     protected function setUp()
     {
+        /** @var \Magento\Framework\DB\Select|\PHPUnit_Framework_MockObject_MockObject $selectMock */
+        $selectMock = $this->getMockBuilder(\Magento\Framework\DB\Select::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['from'])
+            ->getMock();
+        $selectMock->expects($this->any())->method('from')->will($this->returnSelf());
+
+        /** @var $connectionMock \Magento\Framework\DB\Adapter\AdapterInterface|\PHPUnit_Framework_MockObject_MockObject */
+        $connectionMock = $this->getMockBuilder(\Magento\Framework\DB\Adapter\Pdo\Mysql::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['select', 'fetchAll'])
+            ->getMock();
+        $connectionMock->expects($this->any())
+            ->method('select')
+            ->will($this->returnValue($selectMock));
+        $connectionMock->expects($this->any())
+            ->method('fetchAll')
+            ->will($this->returnValue([]));
+
+        /** @var \Magento\Customer\Model\ResourceModel\Customer\Collection|\PHPUnit_Framework_MockObject_MockObject $customerCollection */
+        $customerCollection = $this->getMockBuilder(\Magento\Customer\Model\ResourceModel\Customer\Collection::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getConnection','getMainTable'])
+            ->getMock();
+        $customerCollection->expects($this->any())
+            ->method('getConnection')
+            ->will($this->returnValue($connectionMock));
+
+        $customerCollection->expects($this->any())
+            ->method('getMainTable')
+            ->willReturn('customer_entity');
+
+        /** @var \Magento\Customer\Model\ResourceModel\Customer\CollectionFactory|\PHPUnit_Framework_MockObject_MockObject $collectionFactory */
+        $collectionFactory = $this->getMockBuilder(\Magento\Customer\Model\ResourceModel\Customer\CollectionFactory::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['create'])
+            ->getMock();
+        $collectionFactory->expects($this->any())
+            ->method('create')
+            ->willReturn($customerCollection);
+
+        /** @var \Magento\ImportExport\Model\ResourceModel\CollectionByPagesIteratorFactory|\PHPUnit_Framework_MockObject_MockObject $byPagesIteratorFactory */
+        $byPagesIteratorFactory = $this->getMockBuilder(\Magento\ImportExport\Model\ResourceModel\CollectionByPagesIteratorFactory::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['create'])
+            ->getMock();
+
         $this->_model = new \Magento\CustomerImportExport\Model\ResourceModel\Import\Customer\Storage(
-            $this->getMockBuilder(\Magento\Customer\Model\ResourceModel\Customer\CollectionFactory::class)
-                ->disableOriginalConstructor()
-                ->getMock(),
-            $this->getMockBuilder(\Magento\ImportExport\Model\ResourceModel\CollectionByPagesIteratorFactory::class)
-                ->disableOriginalConstructor()
-                ->getMock(),
-            $this->_getModelDependencies()
+            $collectionFactory,
+            $byPagesIteratorFactory
         );
         $this->_model->load();
     }
@@ -41,59 +83,6 @@ class StorageTest extends \PHPUnit\Framework\TestCase
     protected function tearDown()
     {
         unset($this->_model);
-    }
-
-    /**
-     * Retrieve all necessary objects mocks which used inside customer storage
-     *
-     * @return array
-     */
-    protected function _getModelDependencies()
-    {
-        $select = $this->getMockBuilder(\Magento\Framework\DB\Select::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['from'])
-            ->getMock();
-        $select->expects($this->any())->method('from')->will($this->returnCallback([$this, 'validateFrom']));
-        $customerCollection = $this->getMockBuilder(\Magento\Customer\Model\ResourceModel\Customer\Collection::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['load', 'removeAttributeToSelect', 'getResource', 'getSelect'])
-            ->getMock();
-
-        $resourceStub = new \Magento\Framework\DataObject();
-        $resourceStub->setEntityTable($this->_entityTable);
-        $customerCollection->expects($this->once())->method('getResource')->will($this->returnValue($resourceStub));
-
-        $customerCollection->expects($this->once())->method('getSelect')->will($this->returnValue($select));
-
-        $byPagesIterator = $this->createPartialMock(\stdClass::class, ['iterate']);
-        $byPagesIterator->expects($this->once())
-            ->method('iterate')
-            ->will($this->returnCallback([$this, 'iterate']));
-
-        return [
-            'customer_collection' => $customerCollection,
-            'collection_by_pages_iterator' => $byPagesIterator,
-            'page_size' => 10
-        ];
-    }
-
-    /**
-     * Iterate stub
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param \Magento\Framework\Data\Collection $collection
-     * @param int $pageSize
-     * @param array $callbacks
-     */
-    public function iterate(\Magento\Framework\Data\Collection $collection, $pageSize, array $callbacks)
-    {
-        foreach ($collection as $customer) {
-            foreach ($callbacks as $callback) {
-                call_user_func($callback, $customer);
-            }
-        }
     }
 
     /**
@@ -117,8 +106,7 @@ class StorageTest extends \PHPUnit\Framework\TestCase
         $customer = $this->_addCustomerToStorage();
 
         $this->assertAttributeCount(1, $propertyName, $this->_model);
-
-        $expectedCustomerData = [$customer->getWebsiteId() => $customer->getId()];
+        $expectedCustomerData = [$customer['website_id'] => $customer['entity_id']];
         $this->assertAttributeContains($expectedCustomerData, $propertyName, $this->_model);
     }
 
@@ -127,19 +115,19 @@ class StorageTest extends \PHPUnit\Framework\TestCase
         $customer = $this->_addCustomerToStorage();
 
         $this->assertEquals(
-            $customer->getId(),
-            $this->_model->getCustomerId($customer->getEmail(), $customer->getWebsiteId())
+            $customer['entity_id'],
+            $this->_model->getCustomerId($customer['email'], $customer['website_id'])
         );
-        $this->assertFalse($this->_model->getCustomerId('new@test.com', $customer->getWebsiteId()));
+        $this->assertFalse($this->_model->getCustomerId('new@test.com', $customer['website_id']));
     }
 
     /**
-     * @return \Magento\Framework\DataObject
+     * @return array
      */
     protected function _addCustomerToStorage()
     {
-        $customer = new \Magento\Framework\DataObject(['id' => 1, 'website_id' => 1, 'email' => 'test@test.com']);
-        $this->_model->addCustomer($customer);
+        $customer = ['entity_id' => 1, 'website_id' => 1, 'email' => 'test@test.com'];
+        $this->_model->addCustomerByArray($customer);
 
         return $customer;
     }

--- a/app/code/Magento/CustomerImportExport/Test/Unit/Model/ResourceModel/Import/Customer/StorageTest.php
+++ b/app/code/Magento/CustomerImportExport/Test/Unit/Model/ResourceModel/Import/Customer/StorageTest.php
@@ -102,6 +102,20 @@ class StorageTest extends \PHPUnit\Framework\TestCase
 
     public function testAddCustomer()
     {
+        $customer = new \Magento\Framework\DataObject(['id' => 1, 'website_id' => 1, 'email' => 'test@test.com']);
+        $this->_model->addCustomer($customer);
+
+        $propertyName = '_customerIds';
+        $this->assertAttributeCount(1, $propertyName, $this->_model);
+        $this->assertAttributeContains([$customer->getWebsiteId() => $customer->getId()], $propertyName, $this->_model);
+        $this->assertEquals(
+            $customer->getId(),
+            $this->_model->getCustomerId($customer->getEmail(), $customer->getWebsiteId())
+        );
+    }
+
+    public function testAddCustomerByArray()
+    {
         $propertyName = '_customerIds';
         $customer = $this->_addCustomerToStorage();
 

--- a/app/code/Magento/CustomerImportExport/Test/Unit/Model/ResourceModel/Import/Customer/StorageTest.php
+++ b/app/code/Magento/CustomerImportExport/Test/Unit/Model/ResourceModel/Import/Customer/StorageTest.php
@@ -6,6 +6,10 @@
 namespace Magento\CustomerImportExport\Test\Unit\Model\ResourceModel\Import\Customer;
 
 use Magento\CustomerImportExport\Model\ResourceModel\Import\Customer\Storage;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Customer\Model\ResourceModel\Customer\Collection;
+use Magento\Customer\Model\ResourceModel\Customer\CollectionFactory;
+use Magento\ImportExport\Model\ResourceModel\CollectionByPagesIteratorFactory;
 
 class StorageTest extends \PHPUnit\Framework\TestCase
 {
@@ -33,7 +37,7 @@ class StorageTest extends \PHPUnit\Framework\TestCase
             ->getMock();
         $selectMock->expects($this->any())->method('from')->will($this->returnSelf());
 
-        /** @var $connectionMock \Magento\Framework\DB\Adapter\AdapterInterface|\PHPUnit_Framework_MockObject_MockObject */
+        /** @var $connectionMock AdapterInterface|\PHPUnit_Framework_MockObject_MockObject */
         $connectionMock = $this->getMockBuilder(\Magento\Framework\DB\Adapter\Pdo\Mysql::class)
             ->disableOriginalConstructor()
             ->setMethods(['select', 'fetchAll'])
@@ -45,8 +49,8 @@ class StorageTest extends \PHPUnit\Framework\TestCase
             ->method('fetchAll')
             ->will($this->returnValue([]));
 
-        /** @var \Magento\Customer\Model\ResourceModel\Customer\Collection|\PHPUnit_Framework_MockObject_MockObject $customerCollection */
-        $customerCollection = $this->getMockBuilder(\Magento\Customer\Model\ResourceModel\Customer\Collection::class)
+        /** @var Collection|\PHPUnit_Framework_MockObject_MockObject $customerCollection */
+        $customerCollection = $this->getMockBuilder(Collection::class)
             ->disableOriginalConstructor()
             ->setMethods(['getConnection','getMainTable'])
             ->getMock();
@@ -58,8 +62,8 @@ class StorageTest extends \PHPUnit\Framework\TestCase
             ->method('getMainTable')
             ->willReturn('customer_entity');
 
-        /** @var \Magento\Customer\Model\ResourceModel\Customer\CollectionFactory|\PHPUnit_Framework_MockObject_MockObject $collectionFactory */
-        $collectionFactory = $this->getMockBuilder(\Magento\Customer\Model\ResourceModel\Customer\CollectionFactory::class)
+        /** @var CollectionFactory|\PHPUnit_Framework_MockObject_MockObject $collectionFactory */
+        $collectionFactory = $this->getMockBuilder(CollectionFactory::class)
             ->disableOriginalConstructor()
             ->setMethods(['create'])
             ->getMock();
@@ -67,13 +71,13 @@ class StorageTest extends \PHPUnit\Framework\TestCase
             ->method('create')
             ->willReturn($customerCollection);
 
-        /** @var \Magento\ImportExport\Model\ResourceModel\CollectionByPagesIteratorFactory|\PHPUnit_Framework_MockObject_MockObject $byPagesIteratorFactory */
-        $byPagesIteratorFactory = $this->getMockBuilder(\Magento\ImportExport\Model\ResourceModel\CollectionByPagesIteratorFactory::class)
+        /** @var CollectionByPagesIteratorFactory|\PHPUnit_Framework_MockObject_MockObject $byPagesIteratorFactory */
+        $byPagesIteratorFactory = $this->getMockBuilder(CollectionByPagesIteratorFactory::class)
             ->disableOriginalConstructor()
             ->setMethods(['create'])
             ->getMock();
 
-        $this->_model = new \Magento\CustomerImportExport\Model\ResourceModel\Import\Customer\Storage(
+        $this->_model = new Storage(
             $collectionFactory,
             $byPagesIteratorFactory
         );


### PR DESCRIPTION
### Description
With the following settings a customer import would crash with an out of memory problem.

1. Current database of 250k customers (can be created using bin/magento setup:perf:generate-fixtures setup/performance-toolkit/profiles/ce/small.xml and editing the small.xml to setup 250000 customers)
2. Memory limit set via .htaccess to 268M

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento-engcom/import-export-improvements#43: Failure to allocate memory error when importing customers in admin

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. After setting up the database and memory limit as described visit the admin section and try to import at least 1 customer,

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
