### PR TITLE
[MAGETWO-1556] Export: Unable to Filter Data by Attribute With Input …

### DIFF
--- a/app/code/Magento/ImportExport/Block/Adminhtml/Export/Filter.php
+++ b/app/code/Magento/ImportExport/Block/Adminhtml/Export/Filter.php
@@ -142,7 +142,7 @@ class Filter extends \Magento\Backend\Block\Widget\Grid\Extended
         if ($attribute->getFilterOptions()) {
             $options = $attribute->getFilterOptions();
         } else {
-            $options = $attribute->getSource()->getAllOptions(false);
+            $options = $attribute->getSource()->getAllOptions();
 
             foreach ($options as $key => $optionParams) {
                 if ('' === $optionParams['value']) {
@@ -151,12 +151,13 @@ class Filter extends \Magento\Backend\Block\Widget\Grid\Extended
                 }
             }
         }
+
         if ($size = count($options)) {
             $arguments = [
                 'name' => $this->getFilterElementName($attribute->getAttributeCode()) . '[]',
                 'id' => $this->getFilterElementId($attribute->getAttributeCode()),
                 'class' => 'multiselect multiselect-export-filter',
-                'extra_params' => 'multiple="multiple" size="' . ($size > 5 ? 5 : ($size < 2 ? 2 : $size)),
+                'extra_params' => 'multiple="multiple" size="' . ($size > 5 ? 5 : ($size < 2 ? 2 : $size)) . '"',
             ];
             /** @var $selectBlock \Magento\Framework\View\Element\Html\Select */
             $selectBlock = $this->_layout->createBlock(
@@ -363,6 +364,9 @@ class Filter extends \Magento\Backend\Block\Widget\Grid\Extended
         switch ($filterType) {
             case \Magento\ImportExport\Model\Export::FILTER_TYPE_SELECT:
                 $cell = $this->_getSelectHtmlWithValue($row, $value);
+                break;
+            case \Magento\ImportExport\Model\Export::FILTER_TYPE_MULTISELECT:
+                $cell = $this->_getMultiSelectHtmlWithValue($row, $value);
                 break;
             case \Magento\ImportExport\Model\Export::FILTER_TYPE_INPUT:
                 $cell = $this->_getInputHtmlWithValue($row, $value);

--- a/app/code/Magento/ImportExport/Model/Export.php
+++ b/app/code/Magento/ImportExport/Model/Export.php
@@ -30,7 +30,7 @@ class Export extends \Magento\ImportExport\Model\AbstractModel
      */
     const FILTER_TYPE_SELECT = 'select';
 
-    const FILTER_TYPE_MULTISELECT ='multiselect';
+    const FILTER_TYPE_MULTISELECT = 'multiselect';
 
     const FILTER_TYPE_INPUT = 'input';
 
@@ -68,6 +68,17 @@ class Export extends \Magento\ImportExport\Model\AbstractModel
     protected $_exportAdapterFac;
 
     /**
+     * @var array
+     */
+    public static $backendTypeToFilterMapper = [
+        'datetime' => self::FILTER_TYPE_DATE,
+        'decimal' => self::FILTER_TYPE_NUMBER,
+        'int' => self::FILTER_TYPE_NUMBER,
+        'varchar' => self::FILTER_TYPE_INPUT,
+        'text' => self::FILTER_TYPE_INPUT
+    ];
+
+    /**
      * @param \Psr\Log\LoggerInterface $logger
      * @param \Magento\Framework\Filesystem $filesystem
      * @param \Magento\ImportExport\Model\Export\ConfigInterface $exportConfig
@@ -82,7 +93,8 @@ class Export extends \Magento\ImportExport\Model\AbstractModel
         \Magento\ImportExport\Model\Export\Entity\Factory $entityFactory,
         \Magento\ImportExport\Model\Export\Adapter\Factory $exportAdapterFac,
         array $data = []
-    ) {
+    )
+    {
         $this->_exportConfig = $exportConfig;
         $this->_entityFactory = $entityFactory;
         $this->_exportAdapterFac = $exportAdapterFac;
@@ -219,19 +231,19 @@ class Export extends \Magento\ImportExport\Model\AbstractModel
         if ($attribute->usesSource() || $attribute->getFilterOptions()) {
             return 'multiselect' == $attribute->getFrontendInput() ?
                 self::FILTER_TYPE_MULTISELECT : self::FILTER_TYPE_SELECT;
-        } elseif ('datetime' == $attribute->getBackendType()) {
-            return self::FILTER_TYPE_DATE;
-        } elseif ('decimal' == $attribute->getBackendType() || 'int' == $attribute->getBackendType()) {
-            return self::FILTER_TYPE_NUMBER;
-        } elseif ('varchar' == $attribute->getBackendType() || 'text' == $attribute->getBackendType()) {
-            return self::FILTER_TYPE_INPUT;
-        } elseif ($attribute->isStatic()) {
-            return self::getStaticAttributeFilterType($attribute);
-        } else {
-            throw new \Magento\Framework\Exception\LocalizedException(
-                __('We can\'t determine the attribute filter type.')
-            );
         }
+
+        if (isset(self::$backendTypeToFilterMapper[$attribute->getBackendType()])) {
+            return self::$backendTypeToFilterMapper[$attribute->getBackendType()];
+        }
+
+        if ($attribute->isStatic()) {
+            return self::getStaticAttributeFilterType($attribute);
+        }
+
+        throw new \Magento\Framework\Exception\LocalizedException(
+            __('We can\'t determine the attribute filter type.')
+        );
     }
 
     /**

--- a/app/code/Magento/ImportExport/Model/Export.php
+++ b/app/code/Magento/ImportExport/Model/Export.php
@@ -30,6 +30,8 @@ class Export extends \Magento\ImportExport\Model\AbstractModel
      */
     const FILTER_TYPE_SELECT = 'select';
 
+    const FILTER_TYPE_MULTISELECT ='multiselect';
+
     const FILTER_TYPE_INPUT = 'input';
 
     const FILTER_TYPE_DATE = 'date';
@@ -215,7 +217,8 @@ class Export extends \Magento\ImportExport\Model\AbstractModel
     public static function getAttributeFilterType(\Magento\Eav\Model\Entity\Attribute $attribute)
     {
         if ($attribute->usesSource() || $attribute->getFilterOptions()) {
-            return self::FILTER_TYPE_SELECT;
+            return 'multiselect' == $attribute->getFrontendInput() ?
+                self::FILTER_TYPE_MULTISELECT : self::FILTER_TYPE_SELECT;
         } elseif ('datetime' == $attribute->getBackendType()) {
             return self::FILTER_TYPE_DATE;
         } elseif ('decimal' == $attribute->getBackendType() || 'int' == $attribute->getBackendType()) {

--- a/app/code/Magento/ImportExport/Model/Export.php
+++ b/app/code/Magento/ImportExport/Model/Export.php
@@ -70,7 +70,7 @@ class Export extends \Magento\ImportExport\Model\AbstractModel
     /**
      * @var array
      */
-    public static $backendTypeToFilterMapper = [
+    protected static $backendTypeToFilterMapper = [
         'datetime' => self::FILTER_TYPE_DATE,
         'decimal' => self::FILTER_TYPE_NUMBER,
         'int' => self::FILTER_TYPE_NUMBER,

--- a/app/code/Magento/ImportExport/Model/Export.php
+++ b/app/code/Magento/ImportExport/Model/Export.php
@@ -70,7 +70,7 @@ class Export extends \Magento\ImportExport\Model\AbstractModel
     /**
      * @var array
      */
-    protected static $backendTypeToFilterMapper = [
+    private static $backendTypeToFilterMapper = [
         'datetime' => self::FILTER_TYPE_DATE,
         'decimal' => self::FILTER_TYPE_NUMBER,
         'int' => self::FILTER_TYPE_NUMBER,

--- a/app/code/Magento/ImportExport/Model/Export.php
+++ b/app/code/Magento/ImportExport/Model/Export.php
@@ -93,8 +93,7 @@ class Export extends \Magento\ImportExport\Model\AbstractModel
         \Magento\ImportExport\Model\Export\Entity\Factory $entityFactory,
         \Magento\ImportExport\Model\Export\Adapter\Factory $exportAdapterFac,
         array $data = []
-    )
-    {
+    ) {
         $this->_exportConfig = $exportConfig;
         $this->_entityFactory = $entityFactory;
         $this->_exportAdapterFac = $exportAdapterFac;

--- a/app/code/Magento/ImportExport/Model/Export/Entity/AbstractEav.php
+++ b/app/code/Magento/ImportExport/Model/Export/Entity/AbstractEav.php
@@ -152,13 +152,24 @@ abstract class AbstractEav extends \Magento\ImportExport\Model\Export\AbstractEn
             // filter applying
             if (isset($exportFilter[$attributeCode])) {
                 $attributeFilterType = Export::getAttributeFilterType($attribute);
-
                 if (Export::FILTER_TYPE_SELECT == $attributeFilterType) {
                     if (is_scalar($exportFilter[$attributeCode]) && trim($exportFilter[$attributeCode])) {
                         $collection->addAttributeToFilter(
                             $attributeCode,
                             ['eq' => $exportFilter[$attributeCode]]
                         );
+                    }
+                } elseif (Export::FILTER_TYPE_MULTISELECT == $attributeFilterType) {
+                    if (is_array($exportFilter[$attributeCode])) {
+                        array_filter($exportFilter[$attributeCode]);
+                        if (!empty($exportFilter[$attributeCode])) {
+                            foreach ($exportFilter[$attributeCode] as $val) {
+                                $collection->addAttributeToFilter(
+                                    $attributeCode,
+                                    ['finset' => $val]
+                                );
+                            }
+                        }
                     }
                 } elseif (Export::FILTER_TYPE_INPUT == $attributeFilterType) {
                     if (is_scalar($exportFilter[$attributeCode]) && trim($exportFilter[$attributeCode])) {

--- a/app/code/Magento/ImportExport/Model/Export/Entity/AbstractEntity.php
+++ b/app/code/Magento/ImportExport/Model/Export/Entity/AbstractEntity.php
@@ -277,6 +277,18 @@ abstract class AbstractEntity
                     if (is_scalar($exportFilter[$attrCode]) && trim($exportFilter[$attrCode])) {
                         $collection->addAttributeToFilter($attrCode, ['eq' => $exportFilter[$attrCode]]);
                     }
+                } elseif (\Magento\ImportExport\Model\Export::FILTER_TYPE_MULTISELECT == $attrFilterType) {
+                    if (is_array($exportFilter[$attrCode])) {
+                        array_filter($exportFilter[$attrCode]);
+                        if (!empty($exportFilter[$attrCode])) {
+                            foreach ($exportFilter[$attrCode] as $val) {
+                                $collection->addAttributeToFilter(
+                                    $attrCode,
+                                    ['finset' => $val]
+                                );
+                            }
+                        }
+                    }
                 } elseif (\Magento\ImportExport\Model\Export::FILTER_TYPE_INPUT == $attrFilterType) {
                     if (is_scalar($exportFilter[$attrCode]) && trim($exportFilter[$attrCode])) {
                         $collection->addAttributeToFilter($attrCode, ['like' => "%{$exportFilter[$attrCode]}%"]);


### PR DESCRIPTION
…Type Multiple Select

 - added support for multiselect attribute for both product and customer entity

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->


### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento-engcom/import-export-improvements#33: [MAGETWO-1556] Export: Unable to Filter Data by Attribute With Input Type Multiple Select


### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Add multiselect attribute to customer entity
2. Populate data for that newly created attribute
3. Go to Import/Export and select Customer Main data
4. Observe that multiselect attributes are presented as multiselect form field
5. Data is filtered by selected values

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
