### PR TITLE
product images with same name overwrite previous image fix

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Import/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product.php
@@ -1712,7 +1712,7 @@ class Product extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
                 foreach ($rowImages as $column => $columnImages) {
                     foreach ($columnImages as $columnImageKey => $columnImage) {
                         if (!isset($uploadedImages[$columnImage])) {
-                            $uploadedFile = $this->uploadMediaFiles($columnImage, true);
+                            $uploadedFile = $this->uploadMediaFiles($columnImage);
                             $uploadedFile = $uploadedFile ?: $this->getSystemFile($columnImage);
                             if ($uploadedFile) {
                                 $uploadedImages[$columnImage] = $uploadedFile;

--- a/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/ProductTest.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/ProductTest.php
@@ -97,10 +97,16 @@ class ProductTest extends AbstractProductExportImportTestCase
             'simple-product-image' => [
                 [
                     'Magento/CatalogImportExport/Model/Import/_files/media_import_image.php',
-                    'Magento/Catalog/_files/product_with_image.php'
+                    'Magento/Catalog/_files/product_with_image.php',
                 ],
                 [
                     'simple',
+                ],
+                [
+                    "image",
+                    "small_image",
+                    "thumbnail",
+                    "media_gallery"
                 ]
             ],
             'simple-product-crosssell' => [

--- a/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/ProductTest.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/ProductTest.php
@@ -140,4 +140,32 @@ class ProductTest extends AbstractProductExportImportTestCase
     {
         return $this->exportImportDataProvider();
     }
+
+    /**
+     * Fixing https://github.com/magento-engcom/import-export-improvements/issues/50 means that during import images
+     * can now get renamed for this we need to skip the attribute checking and instead check that the images contain
+     * the right beginning part of the name. When an image is named "magento_image.jpeg" but there is already an image
+     * with that name it will now become "magento_image_1.jpeg"
+     *
+     * @param \Magento\Catalog\Model\Product $expectedProduct
+     * @param \Magento\Catalog\Model\Product $actualProduct
+     */
+    protected function assertEqualsSpecificAttributes($expectedProduct, $actualProduct)
+    {
+        if (!empty($actualProduct->getImage())
+            && !empty($expectedProduct->getImage())
+        ) {
+            $this->assertContains('magento_image', $actualProduct->getImage());
+        }
+        if (!empty($actualProduct->getSmallImage())
+            && !empty($expectedProduct->getSmallImage())
+        ) {
+            $this->assertContains('magento_image', $actualProduct->getSmallImage());
+        }
+        if (!empty($actualProduct->getThumbnail())
+            && !empty($expectedProduct->getThumbnail())
+        ) {
+            $this->assertContains('magento_image', $actualProduct->getThumbnail());
+        }
+    }
 }


### PR DESCRIPTION
### Description
Images were not being renamed while uploading bulk products with images. For example, while importing images from paths a/b.jpg, b/b.jpg, c/b.jpg for three different products were overwriting the same file b.jpg in magento 2. I allowed to rename file if was already existed in Magento 2 catalog product folder. So there is no overwriting while uploading same image name with different folders.

### Manual testing scenarios
1. Create A CSV File for import by same name image within multi directory
2. Upload file in pub/media/import directory with directory
3. Login Backend
4. Got to setting >> import
5. Select "Entity Type" Product
6. Select "Import Behavior" Add/Update
7. Upload CSV File
8. Click Button "Check Data "
9. Click "Import"
10. Import will be successful and it will not override the existing images file with same names.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)