### PR TITLE
MAGETWO-84124: Add bundle parent/child relationship during import

### DIFF
--- a/app/code/Magento/BundleImportExport/Model/Import/Product/Type/Bundle.php
+++ b/app/code/Magento/BundleImportExport/Model/Import/Product/Type/Bundle.php
@@ -411,6 +411,7 @@ class Bundle extends \Magento\CatalogImportExport\Model\Import\Product\Type\Abst
                     $this->populateExistingOptions();
                     $this->insertOptions();
                     $this->insertSelections();
+                    $this->insertParentChildRelations();
                     $this->clear();
                 }
             }
@@ -655,6 +656,32 @@ class Bundle extends \Magento\CatalogImportExport\Model\Import\Product\Type\Abst
         }
 
         $this->relationsDataSaver->saveSelections($selections);
+
+        return $this;
+    }
+
+    /**
+     * Insert parent/child product relations
+     *
+     * @return \Magento\CatalogImportExport\Model\Import\Product\Type\AbstractType
+     */
+    protected function insertParentChildRelations()
+    {
+        foreach ($this->_cachedOptions as $productId => $options) {
+            $childIds = [];
+            foreach ($options as $option) {
+                foreach ($option['selections'] as $selection) {
+                    if (!isset($selection['parent_product_id'])) {
+                        if (!isset($this->_cachedSkuToProducts[$selection['sku']])) {
+                            continue;
+                        }
+                        $childIds[] = $this->_cachedSkuToProducts[$selection['sku']];
+                    }
+                }
+
+                $this->relationsDataSaver->saveProductRelations($productId, $childIds);
+            }
+        }
 
         return $this;
     }

--- a/app/code/Magento/BundleImportExport/Model/Import/Product/Type/Bundle.php
+++ b/app/code/Magento/BundleImportExport/Model/Import/Product/Type/Bundle.php
@@ -665,7 +665,7 @@ class Bundle extends \Magento\CatalogImportExport\Model\Import\Product\Type\Abst
      *
      * @return \Magento\CatalogImportExport\Model\Import\Product\Type\AbstractType
      */
-    protected function insertParentChildRelations()
+    private function insertParentChildRelations()
     {
         foreach ($this->_cachedOptions as $productId => $options) {
             $childIds = [];

--- a/app/code/Magento/BundleImportExport/Model/Import/Product/Type/Bundle/RelationsDataSaver.php
+++ b/app/code/Magento/BundleImportExport/Model/Import/Product/Type/Bundle/RelationsDataSaver.php
@@ -18,12 +18,20 @@ class RelationsDataSaver
     private $resource;
 
     /**
+     * @var \Magento\Catalog\Model\ResourceModel\Product\Relation
+     */
+    private $productRelation;
+
+    /**
      * @param \Magento\Framework\App\ResourceConnection $resource
+     * @param \Magento\Catalog\Model\ResourceModel\Product\Relation $productRelation
      */
     public function __construct(
-        \Magento\Framework\App\ResourceConnection $resource
+        \Magento\Framework\App\ResourceConnection $resource,
+        \Magento\Catalog\Model\ResourceModel\Product\Relation $productRelation
     ) {
-        $this->resource = $resource;
+        $this->resource        = $resource;
+        $this->productRelation = $productRelation;
     }
 
     /**
@@ -91,5 +99,18 @@ class RelationsDataSaver
                 ]
             );
         }
+    }
+
+    /**
+     * Saves given parent/child relations.
+     *
+     * @param int $parentId
+     * @param array $childIds
+     *
+     * @return void
+     */
+    public function saveProductRelations($parentId, $childIds)
+    {
+        $this->productRelation->processRelations($parentId, $childIds);
     }
 }

--- a/app/code/Magento/BundleImportExport/Model/Import/Product/Type/Bundle/RelationsDataSaver.php
+++ b/app/code/Magento/BundleImportExport/Model/Import/Product/Type/Bundle/RelationsDataSaver.php
@@ -5,6 +5,9 @@
  */
 namespace Magento\BundleImportExport\Model\Import\Product\Type\Bundle;
 
+use Magento\Catalog\Model\ResourceModel\Product\Relation;
+use Magento\Framework\App\ObjectManager;
+
 /**
  * A bundle product relations (options, selections, etc.) data saver.
  *
@@ -18,20 +21,21 @@ class RelationsDataSaver
     private $resource;
 
     /**
-     * @var \Magento\Catalog\Model\ResourceModel\Product\Relation
+     * @var Relation
      */
     private $productRelation;
 
     /**
      * @param \Magento\Framework\App\ResourceConnection $resource
-     * @param \Magento\Catalog\Model\ResourceModel\Product\Relation $productRelation
+     * @param Relation                                  $productRelation
      */
     public function __construct(
         \Magento\Framework\App\ResourceConnection $resource,
-        \Magento\Catalog\Model\ResourceModel\Product\Relation $productRelation
+        Relation $productRelation = null
     ) {
         $this->resource        = $resource;
-        $this->productRelation = $productRelation;
+        $this->productRelation = $productRelation
+            ?: ObjectManager::getInstance()->get(Relation::class);
     }
 
     /**

--- a/app/code/Magento/BundleImportExport/Test/Unit/Model/Import/Product/Type/Bundle/RelationsDataSaverTest.php
+++ b/app/code/Magento/BundleImportExport/Test/Unit/Model/Import/Product/Type/Bundle/RelationsDataSaverTest.php
@@ -7,6 +7,7 @@
 namespace Magento\BundleImportExport\Test\Unit\Model\Import\Product\Type\Bundle;
 
 use Magento\BundleImportExport\Model\Import\Product\Type\Bundle\RelationsDataSaver;
+use Magento\Catalog\Model\ResourceModel\Product\Relation;
 use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\DB\Adapter\AdapterInterface;
 
@@ -30,6 +31,11 @@ class RelationsDataSaverTest extends \PHPUnit\Framework\TestCase
      */
     private $connectionMock;
 
+    /**
+     * @var Relation|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $productRelationMock;
+
     protected function setUp()
     {
         $helper = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
@@ -39,12 +45,16 @@ class RelationsDataSaverTest extends \PHPUnit\Framework\TestCase
         $this->connectionMock = $this->getMockBuilder(AdapterInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->resourceMock->expects($this->once())->method('getConnection')->willReturn($this->connectionMock);
+
+        $this->productRelationMock = $this->getMockBuilder(Relation::class)
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $this->relationsDataSaver = $helper->getObject(
             RelationsDataSaver::class,
             [
-                'resource' => $this->resourceMock
+                'resource' => $this->resourceMock,
+                'productRelation' => $this->productRelationMock
             ]
         );
     }
@@ -53,7 +63,7 @@ class RelationsDataSaverTest extends \PHPUnit\Framework\TestCase
     {
         $options = [1, 2];
         $table_name= 'catalog_product_bundle_option';
-
+        $this->resourceMock->expects($this->once())->method('getConnection')->willReturn($this->connectionMock);
         $this->resourceMock->expects($this->once())
             ->method('getTableName')
             ->with('catalog_product_bundle_option')
@@ -78,6 +88,7 @@ class RelationsDataSaverTest extends \PHPUnit\Framework\TestCase
         $optionsValues = [1, 2];
         $table_name= 'catalog_product_bundle_option_value';
 
+        $this->resourceMock->expects($this->once())->method('getConnection')->willReturn($this->connectionMock);
         $this->resourceMock->expects($this->once())
             ->method('getTableName')
             ->with('catalog_product_bundle_option_value')
@@ -98,6 +109,7 @@ class RelationsDataSaverTest extends \PHPUnit\Framework\TestCase
         $selections = [1, 2];
         $table_name= 'catalog_product_bundle_selection';
 
+        $this->resourceMock->expects($this->once())->method('getConnection')->willReturn($this->connectionMock);
         $this->resourceMock->expects($this->once())
             ->method('getTableName')
             ->with('catalog_product_bundle_selection')
@@ -120,5 +132,17 @@ class RelationsDataSaverTest extends \PHPUnit\Framework\TestCase
             );
 
         $this->relationsDataSaver->saveSelections($selections);
+    }
+
+    public function testSaveProductRelations()
+    {
+        $parentId = 1;
+        $children = [2, 3];
+
+        $this->productRelationMock->expects($this->once())
+            ->method('processRelations')
+            ->with($parentId, $children);
+
+        $this->relationsDataSaver->saveProductRelations($parentId, $children);
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
* Save parent/child relationships for bundled products during import process.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#12330: Imported bundle products are not assigned stock status
2. #80 

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Create Bundled product with options
2. Export product via System -> Import/Export
3. Re-upload CSV choosing "Replace" method

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
