### PR TITLE
magento-engcom/import-export-improvements#64: fix issue with Export Type UI

### DIFF
--- a/app/code/Magento/ImportExport/view/adminhtml/templates/export/form/before.phtml
+++ b/app/code/Magento/ImportExport/view/adminhtml/templates/export/form/before.phtml
@@ -64,6 +64,7 @@ require([
                     this.modifyFilterGrid();
                 }
             } else {
+                this.previousGridEntity = '';
                 $('export_filter_container').hide();
             }
         }


### PR DESCRIPTION
### Description

 - reset the entity type in the export form JS
 - this change was made so that if you choose an entity type, then choose the "Please Select" option the entity type gets reset and so now if you choose another type the form will actually be shown

### Fixed Issues (if relevant)
1. magento-engcom/import-export-improvements#64: Export UI is absent after reselecting entity type

### Manual testing scenarios
1. Go to System -> Export in Admin Pane
1. Select for example Products entity type
1. Select "- Please Select -" option of Entity Type dropdown
1. Repeat step 2

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
