### PR TITLE
magento-engcom/import-export-improvements#58: Fix generation of import url

### DIFF
--- a/app/code/Magento/ImportExport/view/adminhtml/templates/import/form/before.phtml
+++ b/app/code/Magento/ImportExport/view/adminhtml/templates/import/form/before.phtml
@@ -178,9 +178,13 @@ require([
                 .loader('show');
             var form = jQuery('#edit_form')
                 .one('invalid-form.validate', function(e){jQuery('body').loader('hide')});
-            newActionUrl = (newActionUrl ? newActionUrl : form.attr('action')) +
-                (form.attr('action').lastIndexOf('?') != -1 ? '&' : '?')+
-                'form_key=' + encodeURIComponent(form.find('[name="form_key"]').val());
+
+            newActionUrl = (newActionUrl ? newActionUrl : form.attr('action'));
+            if (newActionUrl.lastIndexOf('form_key') === -1) {
+                newActionUrl = newActionUrl +
+                    (newActionUrl.lastIndexOf('?') !== -1 ? '&' : '?') +
+                    'form_key=' + encodeURIComponent(form.find('[name="form_key"]').val());
+            }
 
             form.trigger('save', [{
                 action: newActionUrl,


### PR DESCRIPTION
### Description
 - update the building of import url in before.phtml
 - check that we do not already have the form_key in our url,
 - build the newActionUrl first so that we always are using the same url to build the url

### Fixed Issues (if relevant)
1. magento-engcom/import-export-improvements#58: Incorrect Request URL with Form Key on the product import

### Manual testing scenarios
1. Install Magento from develop branch.
1. Go to Admin Panel
1. Go to System -> Import.
1. Select "Products" in Entity Type field.
1. Set: Import Behavior: "Add/Update", select valid file to import.
1. Click "Check Data", wait for validation to complete.
1. Click "Import".
1. Check the url in the network tab of your browser,

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
