### PR TITLE
magento-engcom/import-export-improvements#88: Set store id on import product category initialization to 0

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/CategoryProcessor.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/CategoryProcessor.php
@@ -75,6 +75,7 @@ class CategoryProcessor
             $collection->addAttributeToSelect('name')
                 ->addAttributeToSelect('url_key')
                 ->addAttributeToSelect('url_path');
+            $collection->setStoreId(\Magento\Store\Model\Store::DEFAULT_STORE_ID);
             /* @var $collection \Magento\Catalog\Model\ResourceModel\Category\Collection */
             foreach ($collection as $category) {
                 $structure = explode(self::DELIMITER_CATEGORY, $category->getPath());

--- a/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/_files/products_to_import_with_two_stores.csv
+++ b/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/_files/products_to_import_with_two_stores.csv
@@ -1,4 +1,4 @@
 product_websites,store_view_code,attribute_set_code,product_type,categories,sku,price,name,url_key
-base,,Default,simple,Default Category/category-defaultstore,product,123,product,product
+base,,Default,simple,Default Category/category-admin,product,123,product,product
 ,default,Default,simple,,product,,product-default,product-default
 ,fixturestore,Default,simple,,product,,product-fixture,product-fixture


### PR DESCRIPTION
### Description
It seems that the \Magento\Catalog\Model\ResourceModel\Collection\AbstractCollection will always, when there is no store id supplied, set it to the value supplied by $this->_storeManager->getStore()->getId()) (= 1 for example).
This will result in store 1 values being used to identify the categories on product import instead of the values from admin scope (store 0).

The core behaviour may be questionable, but we can just set it to 0 in our \Model\Import\Product\CategoryProcessor to avoid this.
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento-engcom/import-export-improvements#88

### Manual testing scenarios

Reproduction as described in #88 (short version):

* Create a category 'Test'
* Set the category name to something completely different on default storeview
* Create a csv with catalog product data
* Set 'Default Category/Test' as the 'categories' value
* Import

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
