### PR TITLE
magento-engcom/import-export-improvements#30: Validation should fail when a required field is supplied but is empty after trimming

### DIFF
--- a/app/code/Magento/CustomerImportExport/Model/Import/Customer.php
+++ b/app/code/Magento/CustomerImportExport/Model/Import/Customer.php
@@ -593,6 +593,12 @@ class Customer extends AbstractCustomer
                 if (in_array($attributeCode, $this->_ignoredAttributes)) {
                     continue;
                 }
+                if ($attributeParams['is_required']
+                    && ((!isset($rowData[$attributeCode]) && !$this->_getCustomerId($email, $website))
+                    || (isset($rowData[$attributeCode]) && '' === trim($rowData[$attributeCode])))) {
+                    $this->addRowError(self::ERROR_VALUE_IS_REQUIRED, $rowNumber, $attributeCode);
+                    continue;
+                }
                 if (isset($rowData[$attributeCode]) && strlen($rowData[$attributeCode])) {
                     $this->isAttributeValid(
                         $attributeCode,
@@ -603,8 +609,6 @@ class Customer extends AbstractCustomer
                             ? $this->_parameters[Import::FIELD_FIELD_MULTIPLE_VALUE_SEPARATOR]
                             : Import::DEFAULT_GLOBAL_MULTI_VALUE_SEPARATOR
                     );
-                } elseif ($attributeParams['is_required'] && !$this->_getCustomerId($email, $website)) {
-                    $this->addRowError(self::ERROR_VALUE_IS_REQUIRED, $rowNumber, $attributeCode);
                 }
             }
         }

--- a/app/code/Magento/CustomerImportExport/Model/Import/Customer.php
+++ b/app/code/Magento/CustomerImportExport/Model/Import/Customer.php
@@ -593,12 +593,18 @@ class Customer extends AbstractCustomer
                 if (in_array($attributeCode, $this->_ignoredAttributes)) {
                     continue;
                 }
-                if ($attributeParams['is_required']
-                    && ((!isset($rowData[$attributeCode]) && !$this->_getCustomerId($email, $website))
-                    || (isset($rowData[$attributeCode]) && '' === trim($rowData[$attributeCode])))) {
+
+                $isFieldRequired = $attributeParams['is_required'];
+                $isFieldNotSetAndCustomerDoesNotExist =
+                    !isset($rowData[$attributeCode]) && !$this->_getCustomerId($email, $website);
+                $isFieldSetAndTrimmedValueIsEmpty
+                    = isset($rowData[$attributeCode]) && '' === trim($rowData[$attributeCode]);
+
+                if ($isFieldRequired && ($isFieldNotSetAndCustomerDoesNotExist || $isFieldSetAndTrimmedValueIsEmpty)) {
                     $this->addRowError(self::ERROR_VALUE_IS_REQUIRED, $rowNumber, $attributeCode);
                     continue;
                 }
+
                 if (isset($rowData[$attributeCode]) && strlen($rowData[$attributeCode])) {
                     $this->isAttributeValid(
                         $attributeCode,

--- a/app/code/Magento/ImportExport/Model/Import/ErrorProcessing/ProcessingErrorAggregator.php
+++ b/app/code/Magento/ImportExport/Model/Import/ErrorProcessing/ProcessingErrorAggregator.php
@@ -77,7 +77,7 @@ class ProcessingErrorAggregator implements ProcessingErrorAggregatorInterface
         $errorMessage = null,
         $errorDescription = null
     ) {
-        if ($this->isErrorAlreadyAdded($rowNumber, $errorCode)) {
+        if ($this->isErrorAlreadyAdded($rowNumber, $errorCode, $columnName)) {
             return $this;
         }
         $this->processErrorStatistics($errorLevel);
@@ -333,13 +333,14 @@ class ProcessingErrorAggregator implements ProcessingErrorAggregatorInterface
     /**
      * @param int $rowNum
      * @param string $errorCode
+     * @param string $columnName
      * @return bool
      */
-    protected function isErrorAlreadyAdded($rowNum, $errorCode)
+    protected function isErrorAlreadyAdded($rowNum, $errorCode, $columnName = null)
     {
         $errors = $this->getErrorsByCode([$errorCode]);
         foreach ($errors as $error) {
-            if ($rowNum == $error->getRowNumber()) {
+            if ($rowNum == $error->getRowNumber() && $columnName == $error->getColumnName()) {
                 return true;
             }
         }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
As the issue describes, when on customer import the first name or last name are supplied with a whitespace value, validation will not fail as opposed to editing a customer on the backend. The file succeeds to validate and import. This should not be the case. Furthermore, when both first and last name are invalidated, both validation failures should show on the import messages.

As a solution, I moved the required field validation before the attribute validation and added a check for empty strings after trimming.

Additionally, with that solution, only a validation error for the first failed field would show. This is caused by the error code valueIsRequired / line 1 (for example) is used for each field, but the ProcessingErrorAggregator only allows one error of the same code per line. I did not find out in which scenario this would be relevant and removed the code, undoing an earlier commit.


### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento-engcom/import-export-improvements#30

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Test data for csv:

email | _website | firstname | group_id | lastname
---|---|---|---|---
| test_ifebgl@unknown-domain.com | base |   | 1 |  |

Steps to reproduce

1. Open Backend -> System -> Import/Export -> Import
2. Select Entity Type: Customers
3. Select Import Behaviour: Append Complex Data
4. Select Import Format Version: Magento 1.7 format
5. Select test file
6. Click Check Data button.



### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
