### PR TITLE
Introduce a new configuration field to set the DateTime Format at least for the import/export

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Export/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Export/Product.php
@@ -987,8 +987,8 @@ class Product extends \Magento\ImportExport\Model\Export\Entity\AbstractEntity
                     $fieldName = isset($this->_fieldsMap[$code]) ? $this->_fieldsMap[$code] : $code;
 
                     if ($this->_attributeTypes[$code] == 'datetime') {
-
                         $dateTimeFormat = $this->getDateTimeFormatFromConfig->execute();
+
                         if (in_array($code, $this->dateAttrCodes)
                             || in_array($code, $this->userDefinedAttributes)
                         ) {

--- a/app/code/Magento/Directory/Helper/Data.php
+++ b/app/code/Magento/Directory/Helper/Data.php
@@ -37,6 +37,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     const XML_PATH_DEFAULT_COUNTRY = 'general/country/default';
     const XML_PATH_DEFAULT_LOCALE = 'general/locale/code';
     const XML_PATH_DEFAULT_TIMEZONE = 'general/locale/timezone';
+    const XML_PATH_DEFAULT_DATETIME_FORMAT = 'general/locale/locale_date_format';
     /**#@-*/
 
     /**

--- a/app/code/Magento/Directory/etc/adminhtml/system.xml
+++ b/app/code/Magento/Directory/etc/adminhtml/system.xml
@@ -121,6 +121,10 @@
                     <label>Weight Unit</label>
                     <source_model>Magento\Directory\Model\Config\Source\WeightUnit</source_model>
                 </field>
+                <field id="locale_date_format" translate="label" type="text" sortOrder="8" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>DateTime Format</label>
+                    <comment>Provide information about your preferred datetime format. Documentation can be found: http://userguide.icu-project.org/formatparse/datetime</comment>
+                </field>
             </group>
         </section>
     </system>

--- a/app/code/Magento/Store/etc/di.xml
+++ b/app/code/Magento/Store/etc/di.xml
@@ -282,6 +282,12 @@
             <argument name="scopeType" xsi:type="const">Magento\Store\Model\ScopeInterface::SCOPE_STORE</argument>
         </arguments>
     </type>
+    <type name="Magento\Framework\Stdlib\DateTime\GetDateTimeFormatFromConfig">
+        <arguments>
+            <argument name="defaultDatetimeFormatPath" xsi:type="const">Magento\Directory\Helper\Data::XML_PATH_DEFAULT_DATETIME_FORMAT</argument>
+            <argument name="scopeType" xsi:type="const">Magento\Store\Model\ScopeInterface::SCOPE_STORE</argument>
+        </arguments>
+    </type>
     <type name="Magento\Framework\Locale\Resolver">
         <arguments>
             <argument name="defaultLocalePath" xsi:type="const">Magento\Directory\Helper\Data::XML_PATH_DEFAULT_LOCALE</argument>

--- a/app/etc/di.xml
+++ b/app/etc/di.xml
@@ -144,6 +144,7 @@
     <preference for="Magento\Framework\Locale\FormatInterface" type="Magento\Framework\Locale\Format" />
     <preference for="Magento\Framework\Locale\ResolverInterface" type="Magento\Framework\Locale\Resolver" />
     <preference for="Magento\Framework\Stdlib\DateTime\TimezoneInterface" type="Magento\Framework\Stdlib\DateTime\Timezone" />
+    <preference for="Magento\Framework\Stdlib\DateTime\GetDateTimeFormatFromConfigInterface" type="Magento\Framework\Stdlib\DateTime\GetDateTimeFormatFromConfig" />
     <preference for="Magento\Framework\Communication\ConfigInterface" type="Magento\Framework\Communication\Config" />
     <preference for="Magento\Framework\Module\ResourceInterface" type="Magento\Framework\Module\ModuleResource" />
     <preference for="Magento\Framework\Pricing\Amount\AmountInterface" type="Magento\Framework\Pricing\Amount\Base" />

--- a/lib/internal/Magento/Framework/Stdlib/DateTime/GetDateTimeFormatFromConfig.php
+++ b/lib/internal/Magento/Framework/Stdlib/DateTime/GetDateTimeFormatFromConfig.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Framework\Stdlib\DateTime;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+
+class GetDateTimeFormatFromConfig implements GetDateTimeFormatFromConfigInterface
+{
+
+    /**
+     * @var ScopeConfigInterface
+     */
+    private $_scopeConfig;
+    /**
+     * @var string
+     */
+    private $defaultDatetimeFormatPath;
+    /**
+     * @var string
+     */
+    private $scopeType;
+
+    /**
+     * GetDateTimeFormatFromConfig constructor.
+     *
+     * @param ScopeConfigInterface $scopeConfig
+     * @param string $scopeType
+     * @param string $defaultDatetimeFormatPath
+     */
+    public function __construct(
+        ScopeConfigInterface $scopeConfig,
+        $scopeType,
+        $defaultDatetimeFormatPath
+    ) {
+        $this->_scopeConfig = $scopeConfig;
+        $this->defaultDatetimeFormatPath = $defaultDatetimeFormatPath;
+        $this->scopeType = $scopeType;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function execute($scopeType = null, $scopeCode = null)
+    {
+        return $this->_scopeConfig->getValue(
+            $this->getDefaultDatetimeFormatPath(),
+            $scopeType ?: $this->scopeType,
+            $scopeCode
+        );
+
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getDefaultDatetimeFormatPath()
+    {
+        return $this->defaultDatetimeFormatPath;
+    }
+}

--- a/lib/internal/Magento/Framework/Stdlib/DateTime/GetDateTimeFormatFromConfig.php
+++ b/lib/internal/Magento/Framework/Stdlib/DateTime/GetDateTimeFormatFromConfig.php
@@ -50,7 +50,6 @@ class GetDateTimeFormatFromConfig implements GetDateTimeFormatFromConfigInterfac
             $scopeType ?: $this->scopeType,
             $scopeCode
         );
-
     }
 
     /**

--- a/lib/internal/Magento/Framework/Stdlib/DateTime/GetDateTimeFormatFromConfigInterface.php
+++ b/lib/internal/Magento/Framework/Stdlib/DateTime/GetDateTimeFormatFromConfigInterface.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Framework\Stdlib\DateTime;
+
+/**
+ * @api
+ */
+interface GetDateTimeFormatFromConfigInterface
+{
+    /**
+     * @param string $scopeType
+     * @param string $scopeCode
+     * @return string | null
+     */
+    public function execute($scopeType = null, $scopeCode = null);
+
+    /**
+     * @return string
+     */
+    public function getDefaultDatetimeFormatPath();
+}

--- a/lib/internal/Magento/Framework/Stdlib/Test/Unit/DateTime/GetDateTimeFormatFromConfigTest.php
+++ b/lib/internal/Magento/Framework/Stdlib/Test/Unit/DateTime/GetDateTimeFormatFromConfigTest.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Framework\Stdlib\Test\Unit\DateTime;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\Stdlib\DateTime\GetDateTimeFormatFromConfig;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+
+class GetDateTimeFormatFromConfigTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var ObjectManager
+     */
+    protected $objectManager;
+
+    /**
+     * @var \Magento\Framework\Locale\ResolverInterface | \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $localeResolverMock;
+
+    /**
+     * SetUp Method for GetDateTimeFormatFromConfigTest
+     */
+    protected function setUp()
+    {
+        if (defined('HHVM_VERSION')) {
+            $this->markTestSkipped('Skip this test for hhvm due to problem with \IntlDateFormatter::formatObject');
+        }
+
+        $this->objectManager = new ObjectManager($this);
+    }
+
+    public function dataProviderDateTimeFormat()
+    {
+        /** returns [$dateTimeFormat, $scopeType, $configPath] */
+        return [
+            ['dd.MM.YYYY H:mm:ss', 'stores', 'general/locale/date_time_format'],
+            [null, 'stores', 'general/locale/date_time_format']
+        ];
+    }
+
+    /**
+     * @param $dateTimeFormat
+     * @param $scopeType
+     * @param $configPath
+     *
+     * @dataProvider dataProviderDateTimeFormat
+     */
+    public function testExecuteWillReturnFormat($dateTimeFormat, $scopeType, $configPath)
+    {
+        $scopeConfig = $this->getScopeConfigMock();
+        $scopeConfig
+            ->expects($this->once())
+            ->method('getValue')
+            ->with($configPath, $scopeType, null)
+            ->willReturn($dateTimeFormat);
+
+        $arguments = [
+            'scopeConfig'               => $scopeConfig,
+            'scopeType'                 => $scopeType,
+            'defaultDatetimeFormatPath' => $configPath
+        ];
+
+        $testInstance = $this->getInstanceOfGetDateTimeFromConfig($arguments);
+        $this->assertEquals($dateTimeFormat, $testInstance->execute());
+    }
+
+    // ------------------------------------------------------------------
+    // The following Methods Instanciates Objects, this is just easier to Mock when you need to and when we need twice
+    // of one Object we just can get another. It also makes it easier to manipulate the Methods
+    // ------------------------------------------------------------------
+
+    /**
+     * @param array $arguments
+     *
+     * @return GetDateTimeFormatFromConfig | object
+     */
+    public function getInstanceOfGetDateTimeFromConfig($arguments = [])
+    {
+        return $this->objectManager->getObject(GetDateTimeFormatFromConfig::class, $arguments);
+    }
+
+    /**
+     * @return ScopeConfigInterface | \PHPUnit_Framework_MockObject_MockObject
+     */
+    public function getScopeConfigMock()
+    {
+        return $this->getMockForAbstractClass(ScopeConfigInterface::class);
+    }
+}


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->
This pull request is one step of the general problem, that the import/export is facing, when it's come from export to reimport the same file. One related issue is the #61. This PR fixes one of the reasons, that this could not work.

We ran here into the problem, that the dateformat in standart format looks like eg.
German:  12.11.18 15:42:45
US: 11/12/18 15:42:45

We can't reimport this, because of the PHP "strtotime()" function.
If you called this function with this dateformat, we ran into the issue, that this date could not resolve the "18" as year at the end. Probably PHP tried to lookup for the exact year, and this could be 1918, 2018, 2118, and so on. So this breaks everything.

Now you can set your default datetime in Stores > Configuration > General > Locale > DateTime Format.
It's saved under 'general/locale/locale_date_format'.

### Fixed Issues (if relevant)
1. Probably a small thing of #61 

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
