### PR TITLE
import-export-improvements #82 : super attribute error message improvements

### DIFF
--- a/app/code/Magento/ConfigurableImportExport/Model/Import/Product/Type/Configurable.php
+++ b/app/code/Magento/ConfigurableImportExport/Model/Import/Product/Type/Configurable.php
@@ -41,10 +41,13 @@ class Configurable extends \Magento\CatalogImportExport\Model\Import\Product\Typ
 
     const ERROR_UNIDENTIFIABLE_VARIATION = 'unidentifiableVariation';
 
+    // @codingStandardsIgnoreStart
     /**
      * Validation failure message template definitions
      *
      * @var array
+     *
+     * Note: Many of these messages exceed maximum limit of 120 characters. Ignore from coding standards.
      */
     protected $_messageTemplates = [
         self::ERROR_ATTRIBUTE_CODE_DOES_NOT_EXIST => 'Column configurable_variations: Attribute with code "%s" does not exist or is missing from product attribute set',
@@ -56,6 +59,7 @@ class Configurable extends \Magento\CatalogImportExport\Model\Import\Product\Typ
         self::ERROR_DUPLICATED_VARIATIONS => 'SKU %s contains duplicated variations',
         self::ERROR_UNIDENTIFIABLE_VARIATION => 'Configurable variation "%s" is unidentifiable',
     ];
+    // @codingStandardsIgnoreEnd
 
     /**
      * Column names that holds values with particular meaning.
@@ -300,8 +304,7 @@ class Configurable extends \Magento\CatalogImportExport\Model\Import\Product\Typ
             $superAttrCode = $rowData['_super_attribute_code'];
             if (!$this->_isAttributeSuper($superAttrCode)) {
                 // Identify reason why attribute is not super:
-                if (!$this->_identifySuperAttributeError($superAttrCode, $rowNum))
-                {
+                if (!$this->_identifySuperAttributeError($superAttrCode, $rowNum)) {
                     $this->_entityModel->addRowError(self::ERROR_ATTRIBUTE_CODE_IS_NOT_SUPER, $rowNum, $superAttrCode);
                 }
                 return false;
@@ -334,17 +337,13 @@ class Configurable extends \Magento\CatalogImportExport\Model\Import\Product\Typ
         // Does this attribute code exist? Does is have the correct settings?
         $commonAttributes = self::$commonAttributesCache;
         foreach ($commonAttributes as $attributeRow) {
-
-            if ($attributeRow['code'] == $superAttrCode)
-            {
+            if ($attributeRow['code'] == $superAttrCode) {
                 $codeExists = true;
 
-                if ($attributeRow['is_global'] !== '1')
-                {
+                if ($attributeRow['is_global'] !== '1') {
                     $codeNotGlobal = true;
                 }
-                elseif ($attributeRow['type'] !== 'select')
-                {
+                elseif ($attributeRow['type'] !== 'select') {
                     $codeNotTypeSelect = true;
                 }
 
@@ -352,18 +351,15 @@ class Configurable extends \Magento\CatalogImportExport\Model\Import\Product\Typ
             }
         }
 
-        if ($codeExists == false)
-        {
+        if ($codeExists == false) {
             $this->_entityModel->addRowError(self::ERROR_ATTRIBUTE_CODE_DOES_NOT_EXIST, $rowNum, $superAttrCode);
             $reasonFound = true;
         }
-        elseif ($codeNotGlobal == true)
-        {
+        elseif ($codeNotGlobal == true) {
             $this->_entityModel->addRowError(self::ERROR_ATTRIBUTE_CODE_NOT_GLOBAL_SCOPE, $rowNum, $superAttrCode);
             $reasonFound = true;
         }
-        elseif ($codeNotTypeSelect == true)
-        {
+        elseif ($codeNotTypeSelect == true) {
             $this->_entityModel->addRowError(self::ERROR_ATTRIBUTE_CODE_NOT_TYPE_SELECT, $rowNum, $superAttrCode);
             $reasonFound = true;
         }

--- a/app/code/Magento/ConfigurableImportExport/Model/Import/Product/Type/Configurable.php
+++ b/app/code/Magento/ConfigurableImportExport/Model/Import/Product/Type/Configurable.php
@@ -342,8 +342,7 @@ class Configurable extends \Magento\CatalogImportExport\Model\Import\Product\Typ
 
                 if ($attributeRow['is_global'] !== '1') {
                     $codeNotGlobal = true;
-                }
-                elseif ($attributeRow['type'] !== 'select') {
+                } elseif ($attributeRow['type'] !== 'select') {
                     $codeNotTypeSelect = true;
                 }
 
@@ -354,12 +353,10 @@ class Configurable extends \Magento\CatalogImportExport\Model\Import\Product\Typ
         if ($codeExists == false) {
             $this->_entityModel->addRowError(self::ERROR_ATTRIBUTE_CODE_DOES_NOT_EXIST, $rowNum, $superAttrCode);
             $reasonFound = true;
-        }
-        elseif ($codeNotGlobal == true) {
+        } elseif ($codeNotGlobal == true) {
             $this->_entityModel->addRowError(self::ERROR_ATTRIBUTE_CODE_NOT_GLOBAL_SCOPE, $rowNum, $superAttrCode);
             $reasonFound = true;
-        }
-        elseif ($codeNotTypeSelect == true) {
+        } elseif ($codeNotTypeSelect == true) {
             $this->_entityModel->addRowError(self::ERROR_ATTRIBUTE_CODE_NOT_TYPE_SELECT, $rowNum, $superAttrCode);
             $reasonFound = true;
         }

--- a/app/code/Magento/ConfigurableImportExport/Model/Import/Product/Type/Configurable.php
+++ b/app/code/Magento/ConfigurableImportExport/Model/Import/Product/Type/Configurable.php
@@ -336,7 +336,7 @@ class Configurable extends \Magento\CatalogImportExport\Model\Import\Product\Typ
 
         // Does this attribute code exist?
         $sourceAttribute = $this->doesSuperAttributeExist($superAttrCode);
-        if (!is_null($sourceAttribute)) {
+        if (is_array($sourceAttribute)) {
             $codeExists = true;
             // Does attribute have the correct settings?
             if (isset($sourceAttribute['is_global']) && $sourceAttribute['is_global'] !== '1') {
@@ -374,8 +374,7 @@ class Configurable extends \Magento\CatalogImportExport\Model\Import\Product\Typ
             );
 
             // Return the first element of the filtered array (if found).
-            if (count($filteredAttribute))
-            {
+            if (count($filteredAttribute)) {
                 $returnAttributeArray = array_shift($filteredAttribute);
             }
         }


### PR DESCRIPTION

Improvement to product import error handling for configurable variations column super attribute codes.

### Description

If the standard product import detects that a configurable_variations attribute code is not super one the following error messages will be displayed:

Attribute code does not exist or is not in chosen attribute set.
Attribute code needs to have an Input Type of "Dropdown", "Visual Swatch" or Text Swatch"
Attribute code needs to have a Scope of "Global".

This covers all the reasons why it may not be a not super attribute. Displaying "Attribute with this code is not super" is not helpful enough.

### Fixed Issues (if relevant)

https://github.com/magento-engcom/import-export-improvements/issues/82
Please see the above issue as there is a full comment trace.

### Manual testing scenarios
Try import a configurable product with a super attribute code inside configurable_variations that:
1. doesn't exist
2. exists but is not in the target attribute set
3. is not global scope
4. Is not of type "dropdown", "visual swatch" or "text swatch"


### Contribution checklist
 - [ x ] Pull request has a meaningful description of its purpose
 - [ x ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
