### PR TITLE
 magento-engcom/import-export-improvements#103 Fail product import validation when multiselect columns contain duplicate values

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Import/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product.php
@@ -294,7 +294,8 @@ class Product extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
         ValidatorInterface::ERROR_MEDIA_PATH_NOT_ACCESSIBLE => 'Imported resource (image) does not exist in the local media storage',
         ValidatorInterface::ERROR_MEDIA_URL_NOT_ACCESSIBLE => 'Imported resource (image) could not be downloaded from external resource due to timeout or access permissions',
         ValidatorInterface::ERROR_INVALID_WEIGHT => 'Product weight is invalid',
-        ValidatorInterface::ERROR_DUPLICATE_URL_KEY => 'Url key: \'%s\' was already generated for an item with the SKU: \'%s\'. You need to specify the unique URL key manually'
+        ValidatorInterface::ERROR_DUPLICATE_URL_KEY => 'Url key: \'%s\' was already generated for an item with the SKU: \'%s\'. You need to specify the unique URL key manually',
+        ValidatorInterface::ERROR_DUPLICATE_MULTISELECT_VALUES => "Value for multiselect attribute %s contains duplicated values",
     ];
     //@codingStandardsIgnoreEnd
 

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/RowValidatorInterface.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/RowValidatorInterface.php
@@ -85,6 +85,8 @@ interface RowValidatorInterface extends \Magento\Framework\Validator\ValidatorIn
 
     const ERROR_DUPLICATE_URL_KEY = 'duplicatedUrlKey';
 
+    const ERROR_DUPLICATE_MULTISELECT_VALUES = 'duplicatedMultiselectValues';
+
     /**
      * Value that means all entities (e.g. websites, groups etc.)
      */

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator.php
@@ -219,6 +219,12 @@ class Validator extends AbstractValidator implements RowValidatorInterface
                         break;
                     }
                 }
+
+                $uniqueValues = array_unique($values);
+                if (count($uniqueValues) != count($values)) {
+                    $valid = false;
+                    $this->_addMessages([RowValidatorInterface::ERROR_DUPLICATE_MULTISELECT_VALUES]);
+                }
                 break;
             case 'datetime':
                 $val = trim($rowData[$attrCode]);

--- a/app/code/Magento/CatalogImportExport/Test/Unit/Model/Import/Product/ValidatorTest.php
+++ b/app/code/Magento/CatalogImportExport/Test/Unit/Model/Import/Product/ValidatorTest.php
@@ -169,6 +169,26 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 Import::BEHAVIOR_APPEND,
+                ['is_required' => true, 'type' => 'multiselect',
+                    'options' => ['option 1' => 0, 'option 2' => 1, 'option 3']],
+                ['product_type' => 'any', 'attribute_code' => 'Option 1|Option 2|Option 1'],
+                false
+            ],
+            [
+                Import::BEHAVIOR_APPEND,
+                ['is_required' => true, 'type' => 'multiselect',
+                    'options' => ['option 1' => 0, 'option 2' => 1, 'option 3']],
+                ['product_type' => 'any', 'attribute_code' => 'Option 3|Option 3|Option 3|Option 1'],
+                false
+            ],
+            [
+                Import::BEHAVIOR_APPEND,
+                ['is_required' => true, 'type' => 'multiselect', 'options' => ['option 1' => 0]],
+                ['product_type' => 'any', 'attribute_code' => 'Option 1|Option 1|Option 1|Option 1'],
+                false
+            ],
+            [
+                Import::BEHAVIOR_APPEND,
                 ['is_required' => true, 'type' => 'datetime'],
                 ['product_type' => 'any', 'attribute_code' => '1/1/15 12am'],
                 true


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Introduced a validation failure with message on product import attribute validation of multiselect columns that contain the same value multiple times.

Without this, in 2.2.2 there were reportedly errors on the indexing run. On 2.3, the indexer errors could not be reproduced, but the values are still saved to catalog_product_entity_varchar multiple times.

@dmanners and I agreed that a validation failure in such a case would be appropriate, forcing the user to supply us with clean data.
### Fixed Issues
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1.  magento-engcom/import-export-improvements#103

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

    

1. Create a multiselect attribute, fill it with values (e.g. Dutch, Englisch, French, Chinese)
2. Create an import sheet with a column for the multiselect attribute
3. Fill in duplicate values, for example Dutch|English|French|Chinese|English.
4. Import the sheet.


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
