### PR TITLE
MAGETWO-34709 Changing empty label value for first option on dropdown filters.

### DIFF
--- a/app/code/Magento/ImportExport/Block/Adminhtml/Export/Filter.php
+++ b/app/code/Magento/ImportExport/Block/Adminhtml/Export/Filter.php
@@ -250,7 +250,7 @@ class Filter extends \Magento\Backend\Block\Widget\Grid\Extended
             if ('' === $firstOption['value']) {
                 $options[key($options)]['label'] = '';
             } else {
-                array_unshift($options, ['value' => '', 'label' => '']);
+                array_unshift($options, ['value' => '', 'label' => __('-- Not Selected --')]);
             }
             $arguments = [
                 'name' => $this->getFilterElementName($attribute->getAttributeCode()),


### PR DESCRIPTION
### Description
We have fixed the "empty" option to allow the user to not select any of the options provided on the dropdown filters.

### Fixed Issues
1. magento-engcom/import-export-improvements#62: [MAGETWO-34709] Export Customers Main File: invalid fields are available in export filter

### Manual testing scenarios
1. Make sure you have sample data to test
2. Go to System -> Export in Admin panel
3. Select Customer Main File entity type
4. Select Female gender in Filter column
5. Try to drop (remove) this filter to export both genders (without page reload)
6. Download the file

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
