### PR TITLE
Added $_regionCollection property to class

### DIFF
--- a/app/code/Magento/CustomerImportExport/Model/Import/Address.php
+++ b/app/code/Magento/CustomerImportExport/Model/Import/Address.php
@@ -104,9 +104,9 @@ class Address extends AbstractCustomer
     /**
      * Region collection instance
      *
-     * @var string
+     * @var \Magento\Directory\Model\ResourceModel\Region\Collection
      */
-    protected $_regionCollection;
+    private $_regionCollection;
 
     /**
      * Countries and regions

--- a/app/code/Magento/CustomerImportExport/Model/Import/Address.php
+++ b/app/code/Magento/CustomerImportExport/Model/Import/Address.php
@@ -788,7 +788,7 @@ class Address extends AbstractCustomer
     }
 
     /**
-     * check if address for import is empty (for customer composite mode)
+     * Check if address for import is empty (for customer composite mode)
      *
      * @param array $rowData
      * @return array
@@ -947,7 +947,7 @@ class Address extends AbstractCustomer
     }
 
     /**
-     * set customer attributes
+     * Set customer attributes
      *
      * @param array $customerAttributes
      * @return $this

--- a/app/code/Magento/CustomerImportExport/Model/Import/Address.php
+++ b/app/code/Magento/CustomerImportExport/Model/Import/Address.php
@@ -102,6 +102,13 @@ class Address extends AbstractCustomer
     protected $_entityTable;
 
     /**
+     * Region collection instance
+     *
+     * @var string
+     */
+    protected $_regionCollection;
+
+    /**
      * Countries and regions
      *
      * Example array: array(


### PR DESCRIPTION
### Description (*)
This PR fixes an error detected by PHPStan

### Fixed Issues (if relevant)
1. https://github.com/magento-engcom/import-export-improvements/issues/136: Clean up Model/Import/Address.php

### Manual testing scenarios (*)
1. Run `./vendor/bin/phpstan analyse app/code/Magento/CustomerImportExport/Model/Import/Address.php` as described in https://github.com/magento-engcom/import-export-improvements/issues/136, after this implementation the following errors shouldn't be present

```
------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Line   Address.php
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  318    Access to an undefined property Magento\CustomerImportExport\Model\Import\Address::$_regionCollection.
  431    Access to an undefined property Magento\CustomerImportExport\Model\Import\Address::$_regionCollection.
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
