### PR TITLE
Added $connection property to class

### DIFF
--- a/app/code/Magento/DownloadableImportExport/Helper/Uploader.php
+++ b/app/code/Magento/DownloadableImportExport/Helper/Uploader.php
@@ -39,13 +39,6 @@ class Uploader extends \Magento\Framework\App\Helper\AbstractHelper
     protected $parameters = [];
 
     /**
-     * Connection resource.
-     *
-     * @var \Magento\Framework\DB\Adapter\AdapterInterface
-     */
-    protected $connection = [];
-
-    /**
      * Construct
      *
      * @param \Magento\Framework\App\Helper\Context $context
@@ -53,6 +46,8 @@ class Uploader extends \Magento\Framework\App\Helper\AbstractHelper
      * @param \Magento\CatalogImportExport\Model\Import\UploaderFactory $uploaderFactory
      * @param \Magento\Framework\App\ResourceConnection $resource
      * @param \Magento\Framework\Filesystem $filesystem
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function __construct(
         \Magento\Framework\App\Helper\Context $context,
@@ -67,7 +62,6 @@ class Uploader extends \Magento\Framework\App\Helper\AbstractHelper
         $this->fileUploader->init();
         $this->fileUploader->setAllowedExtensions($this->getAllowedExtensions());
         $this->fileUploader->removeValidateCallback('catalog_product_image');
-        $this->connection = $resource->getConnection('write');
         $this->mediaDirectory = $filesystem->getDirectoryWrite(DirectoryList::ROOT);
     }
 

--- a/app/code/Magento/DownloadableImportExport/Helper/Uploader.php
+++ b/app/code/Magento/DownloadableImportExport/Helper/Uploader.php
@@ -39,6 +39,13 @@ class Uploader extends \Magento\Framework\App\Helper\AbstractHelper
     protected $parameters = [];
 
     /**
+     * Connection resource.
+     *
+     * @var \Magento\Framework\DB\Adapter\AdapterInterface
+     */
+    protected $connection = [];
+
+    /**
      * Construct
      *
      * @param \Magento\Framework\App\Helper\Context $context

--- a/app/code/Magento/DownloadableImportExport/Helper/Uploader.php
+++ b/app/code/Magento/DownloadableImportExport/Helper/Uploader.php
@@ -39,6 +39,11 @@ class Uploader extends \Magento\Framework\App\Helper\AbstractHelper
     protected $parameters = [];
 
     /**
+     * @var \Magento\Framework\DB\Adapter\AdapterInterface
+     */
+    public $connection;
+
+    /**
      * Construct
      *
      * @param \Magento\Framework\App\Helper\Context $context
@@ -62,6 +67,7 @@ class Uploader extends \Magento\Framework\App\Helper\AbstractHelper
         $this->fileUploader->init();
         $this->fileUploader->setAllowedExtensions($this->getAllowedExtensions());
         $this->fileUploader->removeValidateCallback('catalog_product_image');
+        $this->connection = $resource->getConnection('write');
         $this->mediaDirectory = $filesystem->getDirectoryWrite(DirectoryList::ROOT);
     }
 

--- a/app/code/Magento/DownloadableImportExport/Helper/Uploader.php
+++ b/app/code/Magento/DownloadableImportExport/Helper/Uploader.php
@@ -51,8 +51,6 @@ class Uploader extends \Magento\Framework\App\Helper\AbstractHelper
      * @param \Magento\CatalogImportExport\Model\Import\UploaderFactory $uploaderFactory
      * @param \Magento\Framework\App\ResourceConnection $resource
      * @param \Magento\Framework\Filesystem $filesystem
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function __construct(
         \Magento\Framework\App\Helper\Context $context,


### PR DESCRIPTION
### Description (*)
This PR solves the problem addressed in https://github.com/magento-engcom/import-export-improvements/issues/137

### Fixed Issues (if relevant)
1. https://github.com/magento-engcom/import-export-improvements/issues/137: Clean Up Helper/Uploader.php

### Manual testing scenarios (*)
Run `./vendor/bin/phpstan analyse app/code/Magento/DownloadableImportExport/Helper/Uploader.php` as described in https://github.com/magento-engcom/import-export-improvements/issues/137, after this implementation the following errors shouldn't be present

```
------ --------------------------------------------------------------------------------------------------------------------------------
  Line   Uploader.php
 ------ --------------------------------------------------------------------------------------------------------------------------------
  63     Access to an undefined property Magento\DownloadableImportExport\Helper\Uploader::$connection.
 ------ --------------------------------------------------------------------------------------------------------------------------------
```

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
