### PR TITLE
Added $websiteString property to test class

### DIFF
--- a/app/code/Magento/AdvancedPricingImportExport/Test/Unit/Model/Import/AdvancedPricing/Validator/WebsiteTest.php
+++ b/app/code/Magento/AdvancedPricingImportExport/Test/Unit/Model/Import/AdvancedPricing/Validator/WebsiteTest.php
@@ -25,6 +25,11 @@ class WebsiteTest extends \PHPUnit\Framework\TestCase
      */
     protected $website;
 
+    /**
+     * @var \Magento\AdvancedPricingImportExport\Model\Import\AdvancedPricing\Validator\Website|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $websiteString;
+
     protected function setUp()
     {
         $this->webSiteModel = $this->getMockBuilder(\Magento\Store\Model\Website::class)

--- a/app/code/Magento/AdvancedPricingImportExport/Test/Unit/Model/Import/AdvancedPricing/Validator/WebsiteTest.php
+++ b/app/code/Magento/AdvancedPricingImportExport/Test/Unit/Model/Import/AdvancedPricing/Validator/WebsiteTest.php
@@ -25,11 +25,6 @@ class WebsiteTest extends \PHPUnit\Framework\TestCase
      */
     protected $website;
 
-    /**
-     * @var \Magento\AdvancedPricingImportExport\Model\Import\AdvancedPricing\Validator\Website|\PHPUnit_Framework_MockObject_MockObject
-     */
-    protected $websiteString;
-
     protected function setUp()
     {
         $this->webSiteModel = $this->getMockBuilder(\Magento\Store\Model\Website::class)
@@ -108,13 +103,13 @@ class WebsiteTest extends \PHPUnit\Framework\TestCase
         $this->webSiteModel->expects($this->once())->method('getBaseCurrency')->willReturn($currency);
 
         $expectedResult = AdvancedPricing::VALUE_ALL_WEBSITES . ' [' . $currencyCode . ']';
-        $this->websiteString = $this->getMockBuilder(
+        $websiteString = $this->getMockBuilder(
             \Magento\AdvancedPricingImportExport\Model\Import\AdvancedPricing\Validator\Website::class
         )
             ->setMethods(['_clearMessages', '_addMessages'])
             ->setConstructorArgs([$this->storeResolver, $this->webSiteModel])
             ->getMock();
-        $result = $this->websiteString->getAllWebsitesValue();
+        $result = $websiteString->getAllWebsitesValue();
 
         $this->assertEquals($expectedResult, $result);
     }


### PR DESCRIPTION
### Description (*)
This PR solves the problem addressed in https://github.com/magento-engcom/import-export-improvements/issues/132

### Fixed Issues (if relevant)
1. https://github.com/magento-engcom/import-export-improvements/issues/132: 
Clean up app/code/Magento/AdvancedPricingImportExport/Test/Unit/Model/Import/AdvancedPricing/Validator/WebsiteTest.php

### Manual testing scenarios (*)
1. Run `./vendor/bin/phpstan analyse app/code/Magento/AdvancedPricingImportExport/Test/Unit/Model/Import/AdvancedPricing/Validator/WebsiteTest.php`as described in https://github.com/magento-engcom/import-export-improvements/issues/132, after this implementation the following error shouldn't be present

```
------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Line   WebsiteTest.php                                                                                                                                                                     
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  106    Access to an undefined property Magento\AdvancedPricingImportExport\Test\Unit\Model\Import\AdvancedPricing\Validator\WebsiteTest::$websiteString.                                   
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
