### PR TITLE
Fixed miss called property in getStoreIdByCode method

### DIFF
--- a/app/code/Magento/BundleImportExport/Model/Import/Product/Type/Bundle.php
+++ b/app/code/Magento/BundleImportExport/Model/Import/Product/Type/Bundle.php
@@ -20,6 +20,7 @@ use Magento\Store\Model\StoreManagerInterface;
 
 /**
  * Class Bundle
+ *
  * @package Magento\BundleImportExport\Model\Import\Product\Type
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
  */
@@ -349,6 +350,8 @@ class Bundle extends \Magento\CatalogImportExport\Model\Import\Product\Type\Abst
     }
 
     /**
+     * Deprecated method for retrieving mapping between skus and products.
+     *
      * @deprecated Misspelled method
      * @see retrieveProductsByCachedSkus
      */
@@ -600,6 +603,7 @@ class Bundle extends \Magento\CatalogImportExport\Model\Import\Product\Type\Abst
 
     /**
      * Populate array for insert option values
+     *
      * @param array $optionIds
      * @return array
      */

--- a/app/code/Magento/BundleImportExport/Model/Import/Product/Type/Bundle.php
+++ b/app/code/Magento/BundleImportExport/Model/Import/Product/Type/Bundle.php
@@ -779,7 +779,7 @@ class Bundle extends \Magento\CatalogImportExport\Model\Import\Product\Type\Abst
      */
     private function getStoreIdByCode(string $storeCode): int
     {
-        if (!isset($this->storeIdToCode[$storeCode])) {
+        if (!isset($this->storeCodeToId[$storeCode])) {
             /** @var $store \Magento\Store\Model\Store */
             foreach ($this->storeManager->getStores() as $store) {
                 $this->storeCodeToId[$store->getCode()] = $store->getId();


### PR DESCRIPTION
### Description (*)
This PR solves the problem addressed in https://github.com/magento-engcom/import-export-improvements/issues/134

### Fixed Issues (if relevant)
1. https://github.com/magento-engcom/import-export-improvements/issues/134: Clean up Model/Import/Product/Type/Bundle.php

### Manual testing scenarios (*)
1. Run `./vendor/bin/phpstan analyse app/code/Magento/BundleImportExport/Model/Import/Product/Type/Bundle.php` as described in https://github.com/magento-engcom/import-export-improvements/issues/134, after this implementation the following error shouldn't be present

```
------ ------------------------------------------------------------------------------------------------------------------------------------------
  Line   Bundle.php
 ------ ------------------------------------------------------------------------------------------------------------------------------------------
  782    Access to an undefined property Magento\BundleImportExport\Model\Import\Product\Type\Bundle::$storeIdToCode.
 ------ ------------------------------------------------------------------------------------------------------------------------------------------
```

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
