### PR TITLE
Added $_customerCollection property to Storage class

### DIFF
--- a/app/code/Magento/CustomerImportExport/Model/ResourceModel/Import/Customer/Storage.php
+++ b/app/code/Magento/CustomerImportExport/Model/ResourceModel/Import/Customer/Storage.php
@@ -44,30 +44,13 @@ class Storage
     protected $_byPagesIterator;
 
     /**
-     * @var CustomerCollectionFactory
-     */
-    private $customerCollectionFactory;
-
-    /**
-     * Customer collection.
-     *
-     * @var \Magento\Customer\Model\ResourceModel\Customer\Collection
-     */
-    private $_customerCollection;
-
-    /**
-     * @param CustomerCollectionFactory $collectionFactory
      * @param CollectionByPagesIteratorFactory $colIteratorFactory
      * @param array $data
      */
     public function __construct(
-        CustomerCollectionFactory $collectionFactory,
         CollectionByPagesIteratorFactory $colIteratorFactory,
         array $data = []
     ) {
-        $this->_customerCollection = isset(
-            $data['customer_collection']
-        ) ? $data['customer_collection'] : $collectionFactory->create();
         $this->_pageSize = isset($data['page_size']) ? $data['page_size'] : 0;
         $this->_byPagesIterator = isset(
             $data['collection_by_pages_iterator']

--- a/app/code/Magento/CustomerImportExport/Model/ResourceModel/Import/Customer/Storage.php
+++ b/app/code/Magento/CustomerImportExport/Model/ResourceModel/Import/Customer/Storage.php
@@ -44,10 +44,17 @@ class Storage
     protected $_byPagesIterator;
 
     /**
+     * @var CustomerCollectionFactory
+     */
+    private $customerCollectionFactory;
+
+    /**
+     * @param CustomerCollectionFactory $collectionFactory
      * @param CollectionByPagesIteratorFactory $colIteratorFactory
      * @param array $data
      */
     public function __construct(
+        CustomerCollectionFactory $collectionFactory,
         CollectionByPagesIteratorFactory $colIteratorFactory,
         array $data = []
     ) {

--- a/app/code/Magento/CustomerImportExport/Model/ResourceModel/Import/Customer/Storage.php
+++ b/app/code/Magento/CustomerImportExport/Model/ResourceModel/Import/Customer/Storage.php
@@ -49,6 +49,13 @@ class Storage
     private $customerCollectionFactory;
 
     /**
+     * Customer collection.
+     *
+     * @var \Magento\Customer\Model\ResourceModel\Customer\Collection
+     */
+    private $_customerCollection;
+
+    /**
      * @param CustomerCollectionFactory $collectionFactory
      * @param CollectionByPagesIteratorFactory $colIteratorFactory
      * @param array $data

--- a/app/code/Magento/CustomerImportExport/Model/ResourceModel/Import/Customer/Storage.php
+++ b/app/code/Magento/CustomerImportExport/Model/ResourceModel/Import/Customer/Storage.php
@@ -49,6 +49,11 @@ class Storage
     private $customerCollectionFactory;
 
     /**
+     * @var CustomerCollection
+     */
+    public $_customerCollection;
+
+    /**
      * @param CustomerCollectionFactory $collectionFactory
      * @param CollectionByPagesIteratorFactory $colIteratorFactory
      * @param array $data
@@ -58,6 +63,9 @@ class Storage
         CollectionByPagesIteratorFactory $colIteratorFactory,
         array $data = []
     ) {
+        $this->_customerCollection = isset(
+            $data['customer_collection']
+        ) ? $data['customer_collection'] : $collectionFactory->create();
         $this->_pageSize = isset($data['page_size']) ? $data['page_size'] : 0;
         $this->_byPagesIterator = isset(
             $data['collection_by_pages_iterator']

--- a/app/code/Magento/CustomerImportExport/Model/ResourceModel/Import/Customer/Storage.php
+++ b/app/code/Magento/CustomerImportExport/Model/ResourceModel/Import/Customer/Storage.php
@@ -13,6 +13,9 @@ use Magento\Customer\Model\ResourceModel\Customer\Collection as CustomerCollecti
 use Magento\ImportExport\Model\ResourceModel\CollectionByPagesIteratorFactory;
 use Magento\ImportExport\Model\ResourceModel\CollectionByPagesIterator;
 
+/**
+ * Storage to check existing customers.
+ */
 class Storage
 {
     /**
@@ -117,6 +120,8 @@ class Storage
     }
 
     /**
+     * Add a customer by an array
+     *
      * @param array $customer
      * @return $this
      */


### PR DESCRIPTION
### Description (*)
This PR solves the problem addressed in https://github.com/magento-engcom/import-export-improvements/issues/135

### Fixed Issues (if relevant)
1. https://github.com/magento-engcom/import-export-improvements/issues/135: Clean up Model/ResourceModel/Import/Customer/Storage.php

### Manual testing scenarios (*)
1. Run `./vendor/bin/phpstan analyse app/code/Magento/CustomerImportExport/Model/ResourceModel/Import/Customer/Storage.php` as described in https://github.com/magento-engcom/import-export-improvements/issues/135, after this implementation the following error shouldn't be present

```
------ -----------------------------------------------------------------------------------------------------------------------------------------------------------
  Line   Storage.php
 ------ -----------------------------------------------------------------------------------------------------------------------------------------------------------
  61     Access to an undefined property Magento\CustomerImportExport\Model\ResourceModel\Import\Customer\Storage::$_customerCollection.
 ------ -----------------------------------------------------------------------------------------------------------------------------------------------------------
```

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
