### PR TITLE
Define $_storeIdToCode and $_invalidRows properties

### DIFF
--- a/app/code/Magento/ImportExport/Model/Export/Entity/AbstractEntity.php
+++ b/app/code/Magento/ImportExport/Model/Export/Entity/AbstractEntity.php
@@ -149,6 +149,20 @@ abstract class AbstractEntity
     protected $_storeManager;
 
     /**
+     * Array of pairs store ID to its code
+     *
+     * @var array
+     */
+    protected $_storeIdToCode = [];
+
+    /**
+     * Validation information about processed rows
+     *
+     * @var array
+     */
+    protected $_invalidRows = [];
+
+    /**
      * @param \Magento\Framework\Stdlib\DateTime\TimezoneInterface $localeDate
      * @param \Magento\Eav\Model\Config $config
      * @param ResourceConnection $resource


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
- Define $_storeIdToCode and $_invalidRows properties on `\Magento\ImportExport\Model\Export\Entity\AbstractEntity`. I used `\Magento\ImportExport\Model\Export\AbstractEntity` as reference.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento-engcom/import-export-improvements#124: Clean up AbstractEntity attributes 

### Manual testing scenarios (*)
1. Run  `<my_path>/vendor/bin/phpstan analyse -l 0 app/code/Magento/ImportExport/Model/Export/Entity/AbstractEntity.php`
2. Expected result: No errors

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
