### PR TITLE
Clean Up Magento/ImportExport/Controller/Adminhtml/History/Download

### DIFF
--- a/app/code/Magento/ImportExport/Controller/Adminhtml/History/Download.php
+++ b/app/code/Magento/ImportExport/Controller/Adminhtml/History/Download.php
@@ -6,9 +6,10 @@
  */
 namespace Magento\ImportExport\Controller\Adminhtml\History;
 
+use Magento\Framework\App\Action\HttpGetActionInterface;
 use Magento\Framework\App\Filesystem\DirectoryList;
 
-class Download extends \Magento\ImportExport\Controller\Adminhtml\History
+class Download extends \Magento\ImportExport\Controller\Adminhtml\History implements HttpGetActionInterface
 {
     /**
      * @var \Magento\Framework\Controller\Result\RawFactory

--- a/app/code/Magento/ImportExport/Controller/Adminhtml/History/Download.php
+++ b/app/code/Magento/ImportExport/Controller/Adminhtml/History/Download.php
@@ -16,6 +16,11 @@ class Download extends \Magento\ImportExport\Controller\Adminhtml\History
     protected $resultRawFactory;
 
     /**
+     * @var \Magento\Framework\App\Response\Http\FileFactory
+     */
+    private $fileFactory;
+
+    /**
      * @param \Magento\Backend\App\Action\Context $context
      * @param \Magento\Framework\App\Response\Http\FileFactory $fileFactory
      * @param \Magento\Framework\Controller\Result\RawFactory $resultRawFactory


### PR DESCRIPTION
### Description (*)
- This PR solves phpstan error by having defined $fileFactory variable.

### Fixed Issues (if relevant)
1. magento-engcom/import-export-improvements#126: Clean Up Magento/ImportExport/Controller/Adminhtml/History/Download

### Manual testing scenarios (*)
1. Run `./vendor/bin/phpstan analyse -l 0 app/code/Magento/ImportExport/Controller/Adminhtml/History/Download.php` 
2. Expected result: No errors

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
