### PR TITLE
Removed parameter from constructor inside CustomTest class

### DIFF
--- a/app/code/Magento/ImportExport/Test/Unit/Model/Source/Import/Behavior/CustomTest.php
+++ b/app/code/Magento/ImportExport/Test/Unit/Model/Source/Import/Behavior/CustomTest.php
@@ -32,7 +32,7 @@ class CustomTest extends \Magento\ImportExport\Test\Unit\Model\Source\Import\Abs
     protected function setUp()
     {
         parent::setUp();
-        $this->_model = new \Magento\ImportExport\Model\Source\Import\Behavior\Custom([]);
+        $this->_model = new \Magento\ImportExport\Model\Source\Import\Behavior\Custom();
     }
 
     /**


### PR DESCRIPTION
### Description (*)
* this PR solves phpstan error by having parameter inside constructor removed.

### Fixed Issues (if relevant)
1. magento-engcom/import-export-improvements#123:  Call to Magento\ImportExport\Model\Source\Import\Behavior\Custom with constructor arguments

### Manual testing scenarios (*)
1. `./vendor/bin/phpstan analyse -l 0 app/code/Magento/ImportExport/Test/Unit/Model/Source/Import/Behavior/CustomTest.php`
2. Expected result: No errors

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
