### PR TITLE
Define $session property in History model

### DIFF
--- a/app/code/Magento/ImportExport/Model/History.php
+++ b/app/code/Magento/ImportExport/Model/History.php
@@ -298,6 +298,8 @@ class History extends \Magento\Framework\Model\AbstractModel
     }
 
     /**
+     * Load the last inserted item
+     *
      * @return $this
      */
     public function loadLastInsertItem()

--- a/app/code/Magento/ImportExport/Model/History.php
+++ b/app/code/Magento/ImportExport/Model/History.php
@@ -43,6 +43,11 @@ class History extends \Magento\Framework\Model\AbstractModel
     protected $reportHelper;
 
     /**
+     * @var \Magento\Backend\Model\Auth\Session
+     */
+    private $session;
+
+    /**
      * Class constructor
      *
      * @param \Magento\Framework\Model\Context $context


### PR DESCRIPTION
### Description (*)
* this PR solves phpstan error by having $session property defined.

### Fixed Issues (if relevant)
1. magento-engcom/import-export-improvements#122: Cleanup History file

### Manual testing scenarios (*)
1. run `./vendor/bin/phpstan analyse -l 0 app/code/Magento/ImportExport/Model/History.php`
2. Expected result: no errors.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
