### PR TITLE
Fix "no file extension at url" issue

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Import/Uploader.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Uploader.php
@@ -175,7 +175,7 @@ class Uploader extends \Magento\MediaStorage\Model\File\Uploader
             } else {
                 $filePath = '';
             }
-            $fileName = preg_replace('/[^a-z0-9\._-]+/i', '', $fileName);
+            $fileName = $this->getFileNameWithExtension($url, $fileName);
             $filePath = $this->_directory->getRelativePath($filePath . $fileName);
             $this->_directory->writeFile(
                 $filePath,
@@ -358,5 +358,42 @@ class Uploader extends \Magento\MediaStorage\Model\File\Uploader
     protected function chmod($file)
     {
         return;
+    }
+
+    /**
+     * @param string $url
+     * @param string $fileName
+     * @return string
+     */
+    private function getFileNameWithExtension($url, $fileName)
+    {
+        $fileName = preg_replace('/[^a-z0-9\._-]+/i', '', $fileName);
+        if (!$this->isFileNameHasExtension($fileName)) {
+            $fileName .= '.' . $this->getExtensionFromHeaders($url);
+        }
+
+        return $fileName;
+    }
+
+    /**
+     * @param string $fileName
+     * @return bool
+     */
+    private function isFileNameHasExtension($fileName)
+    {
+        $fileNameExploded = explode('.', $fileName);
+
+        return in_array(end($fileNameExploded), array_keys($this->_allowedMimeTypes));
+    }
+
+    /**
+     * @param string $url
+     * @return string
+     */
+    private function getExtensionFromHeaders($url)
+    {
+        $contentTypeExploded = explode('/', get_headers($this->httpScheme . $url, 1)['Content-Type']);
+
+        return end($contentTypeExploded);
     }
 }

--- a/app/code/Magento/CatalogImportExport/Model/Import/Uploader.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Uploader.php
@@ -6,6 +6,7 @@
 namespace Magento\CatalogImportExport\Model\Import;
 
 use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Filesystem\DriverPool;
 
 /**
@@ -146,6 +147,8 @@ class Uploader extends \Magento\MediaStorage\Model\File\Uploader
      * @param string $fileName
      * @param bool $renameFileOff
      * @return array
+     * @throws LocalizedException
+     * @throws \Magento\Framework\Exception\FileSystemException
      */
     public function move($fileName, $renameFileOff = false)
     {
@@ -364,6 +367,7 @@ class Uploader extends \Magento\MediaStorage\Model\File\Uploader
      * @param string $url
      * @param string $fileName
      * @return string
+     * @throws \Exception
      */
     private function getFileNameWithExtension($url, $fileName)
     {
@@ -389,10 +393,16 @@ class Uploader extends \Magento\MediaStorage\Model\File\Uploader
     /**
      * @param string $url
      * @return string
+     * @throws \Exception
      */
     private function getExtensionFromHeaders($url)
     {
-        $contentTypeExploded = explode('/', get_headers($this->httpScheme . $url, 1)['Content-Type']);
+        $headers = get_headers($this->httpScheme . $url, 1);
+        if (array_key_exists('Content-Type', $headers)) {
+            $contentTypeExploded = explode('/', $headers['Content-Type']);
+        } else {
+            throw new LocalizedException(__("File doesn't contain extension or Content-type header"));
+        }
 
         return end($contentTypeExploded);
     }


### PR DESCRIPTION
Fix "no file extension at url" issue

### Description (*)
Magento checks headers for content type and takes file extension 

### Fixed Issues
1. https://github.com/magento-engcom/import-export-improvements/issues/78

### Manual testing scenarios (*)
Described in issue

### Note
Content disposition not used because it's not actually all the time in headers. 