### PR TITLE
Removed method annotation without argument from PHPDoc

### DIFF
--- a/app/code/Magento/Backend/Block/Widget/Grid.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid.php
@@ -12,7 +12,7 @@ namespace Magento\Backend\Block\Widget;
  * @api
  * @deprecated 100.2.0 in favour of UI component implementation
  * @method string getRowClickCallback() getRowClickCallback()
- * @method \Magento\Backend\Block\Widget\Grid setRowClickCallback() setRowClickCallback(string $value)
+ * @method \Magento\Backend\Block\Widget\Grid setRowClickCallback(string $value)
  * @SuppressWarnings(PHPMD.TooManyFields)
  * @since 100.0.2
  */

--- a/app/code/Magento/Backend/Block/Widget/Grid.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid.php
@@ -150,7 +150,10 @@ class Grid extends \Magento\Backend\Block\Widget
     }
 
     /**
+     * Internal constructor, that is called from real constructor
+     *
      * @return void
+     *
      * @SuppressWarnings(PHPMD.NPathComplexity)
      */
     protected function _construct()
@@ -709,6 +712,7 @@ class Grid extends \Magento\Backend\Block\Widget
 
     /**
      * Grid url getter
+     *
      * Version of getGridUrl() but with parameters
      *
      * @param array $params url parameters


### PR DESCRIPTION
### Description
Added argument to PHPDoc annotation @method setRowClickCallback(string $value)

### Fixed Issues
[#125 Clean Up Magento/ImportExport/Block/Adminhtml/Export/Filter](https://github.com/magento-engcom/import-export-improvements/issues/125)

### Manual testing scenarios (*)
Run ./vendor/bin/phpstan analyse -l 0 app/code/Magento/ImportExport/Block/Adminhtml/Export/Filter.php


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
