### PR TITLE
Added go back link to import success page

### DIFF
--- a/app/code/Magento/ImportExport/Controller/Adminhtml/Import/Start.php
+++ b/app/code/Magento/ImportExport/Controller/Adminhtml/Import/Start.php
@@ -109,6 +109,9 @@ class Start extends ImportResultController implements HttpPostActionInterface
 
                 $this->addErrorMessages($resultBlock, $errorAggregator);
                 $resultBlock->addSuccess(__('Import successfully done'));
+
+                $goBackHtml = '<a href="'.$this->getUrl('adminhtml/*/index').'" />'.__('Start import again').'</a>';
+                $resultBlock->addAction('innerHTML', 'import_validation_actions', $goBackHtml);
             }
 
             return $resultLayout;

--- a/app/code/Magento/ImportExport/view/adminhtml/templates/import/form/after.phtml
+++ b/app/code/Magento/ImportExport/view/adminhtml/templates/import/form/after.phtml
@@ -12,6 +12,7 @@
             id="import_validation_container_header"><?= /* @escapeNotVerified */ __('Validation Results') ?></span>
     </div><br>
     <div id="import_validation_messages" class="fieldset"><!-- --></div>
+    <div id="import_validation_actions" class=""><!-- --></div>
 </div>
 <script>
 require(['jquery', 'Magento_Ui/js/modal/alert', 'prototype'], function(jQuery){


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
In my experience working with catalog imports for clients, usually the process is something similar to: run import, check errors in data, fix errors in data, run import again, fix errors again and so on. In that process I see it more convenient to have a "go back" link on success page than having to go to Magento menu System -> Import to start over the process. 
This doesn't resolve an issue. From my point of view, it's just a UX improvement.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
Doesn't solve an existing issue

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Run a successful import
2. Verify there is a link after the success message for starting over

### Contribution checklist (*)
 - [ x] Pull request has a meaningful description of its purpose
 - [ x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
